### PR TITLE
Syntax for importing macros from external modules into scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "optimist": "~0.3.4",
     "underscore": "~1.3.3",
     "escodegen": "1.1.x",
-    "escope": "1.0.x"
+    "escope": "1.0.x",
+    "resolve": "~0.6.1"
   },
   "devDependencies": {
     "mocha": "~1.3.2",

--- a/src/expander.js
+++ b/src/expander.js
@@ -26,6 +26,12 @@
 
 (function (root, factory) {
     if (typeof exports === 'object') {
+        var path = require('path');
+        var fs = require('fs');
+
+        var lib  = path.join(path.dirname(fs.realpathSync(__filename)), "../macros");
+
+        var stxcaseModule = fs.readFileSync(lib + "/stxcase.js", 'utf8');
         // CommonJS
         factory(exports,
                 require('underscore'),
@@ -33,6 +39,7 @@
                 require('./syntax'),
                 require('./scopedEval'),
                 require("./patterns"),
+                stxcaseModule,
                 require('escodegen'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -41,14 +48,16 @@
                 'parser',
                 'syntax',
                 'scopedEval',
-                'patterns'], factory);
+                'patterns',
+                'text!./stxcase.js'], factory);
     }
-}(this, function(exports, _, parser, syn, se, patternModule, gen) {
+}(this, function(exports, _, parser, syn, se, patternModule, stxcaseModule, gen) {
     'use strict';
     var codegen = gen || escodegen;
     var assert = syn.assert;
     var throwSyntaxError = syn.throwSyntaxError;
     var unwrapSyntax = syn.unwrapSyntax;
+    var stxcaseCtx;
 
     macro _get_vars {
 	    case {_ $val { } } => { return #{} }
@@ -820,6 +829,14 @@
         }
     });
 
+    var ImportMacros = TermTree.extend({
+        properties: ["id", "names"],
+        construct: function(id, names) {
+            this.id = id;
+            this.names = names;
+        }
+    });
+
     var ForStatement = Statement.extend({
         properties: ["forkw", "cond"],
 
@@ -1344,6 +1361,27 @@
                         return step(Block.create(head), rest);
                     }
 
+                    ImportMacros(id, names) => {
+                        if (context.resolveModule) {
+                            if (!stxcaseCtx) {
+                                stxcaseCtx = expandModule(parser.read(stxcaseModule));
+                            }
+                            var desc = context.resolveModule(unwrapSyntax(id), context.filename);
+                            var mod = expandModule(parser.read(desc.source), [stxcaseCtx], {
+                                filename: desc.filename,
+                                requireModule: context.requireModule,
+                                resolveModule: context.resolveModule
+                            });
+                            context.env.extend(mod.env);
+                            rest = _.map(rest, function(stx) {
+                                return loadModuleExports(stx, context.env, mod.exports, mod.env);
+                            });
+                            return step(Empty.create(), rest);
+                        } else {
+                            throw new Error("cannot load macro modules");
+                        }
+                    }
+
                     Id(id) | (unwrapSyntax(id) === "#quoteSyntax" && 
                                 rest[0] && rest[0].token.value === "{}") => {
 
@@ -1619,6 +1657,18 @@
                     head.token.type === parser.Token.NullLiteral) {
 
                     return step(Lit.create(head), rest);
+                // import macros
+                } else if (head.token.type === parser.Token.Keyword &&
+                            unwrapSyntax(head) === "import" &&
+                            rest[0] &&
+                                rest[0].token.type === parser.Token.Identifier &&
+                                unwrapSyntax(rest[0]) === "macros" &&
+                            rest[1] &&
+                                rest[1].token.type === parser.Token.Identifier &&
+                                unwrapSyntax(rest[1]) === "from" &&
+                            rest[2] &&
+                                rest[2].token.type === parser.Token.StringLiteral) {
+                    return step(ImportMacros.create(rest[2]), rest.slice(3));
                 // export
                 } else if (head.token.type === parser.Token.Keyword && 
                             unwrapSyntax(head) === "export" && 
@@ -2189,6 +2239,8 @@
                        writable: false, enumerable: true, configurable: false},
             requireModule: {value: o.requireModule,
                             writable: false, enumerable: true, configurable: false},
+            resolveModule: {value: o.resolveModule,
+                            writable: false, enumerable: true, configurable: false},
             env: {value: o.env || new StringMap(),
                   writable: false, enumerable: true, configurable: false},
             defscope: {value: o.defscope,
@@ -2202,10 +2254,12 @@
 
     function makeTopLevelExpanderContext(options) {
         var requireModule = options ? options.requireModule : undefined;
+        var resolveModule = options ? options.resolveModule : undefined;
         var filename = options ? options.filename : undefined;
         return makeExpanderContext({
             filename: filename,
-            requireModule: requireModule
+            requireModule: requireModule,
+            resolveModule: resolveModule
         });
     }
 

--- a/src/expander.js
+++ b/src/expander.js
@@ -1771,6 +1771,12 @@
             makeKeyword: syn.makeKeyword,
             makePunc: syn.makePunc,
             makeDelim: syn.makeDelim,
+            require: function(id) {
+                if (context.requireModule) {
+                    return context.requireModule(id, context.filename);
+                }
+                return require(id);
+            },
             getExpr: function(stx) {
                 var r;
                 if (stx.length === 0) {
@@ -2179,6 +2185,10 @@
         o = o || {};
         // read-only but can enumerate
         return Object.create(Object.prototype, {
+            filename: {value: o.filename,
+                       writable: false, enumerable: true, configurable: false},
+            requireModule: {value: o.requireModule,
+                            writable: false, enumerable: true, configurable: false},
             env: {value: o.env || new StringMap(),
                   writable: false, enumerable: true, configurable: false},
             defscope: {value: o.defscope,
@@ -2190,13 +2200,22 @@
         });
     }
 
+    function makeTopLevelExpanderContext(options) {
+        var requireModule = options ? options.requireModule : undefined;
+        var filename = options ? options.filename : undefined;
+        return makeExpanderContext({
+            filename: filename,
+            requireModule: requireModule
+        });
+    }
+
     // a hack to make the top level hygiene work out
-    function expandTopLevel(stx, moduleContexts, _maxExpands) {
+    function expandTopLevel(stx, moduleContexts, options) {
         moduleContexts = moduleContexts || [];
-        maxExpands = _maxExpands || Infinity;
+        maxExpands = (_.isNumber(options) ? options : options && options._maxExpands) || Infinity;
         expandCount = 0;
 
-        var context = makeExpanderContext();
+        var context = makeTopLevelExpanderContext(options);
         var modBody = syn.makeDelim("{}", stx, null);
         modBody = _.reduce(moduleContexts, function(acc, mod) {
             context.env.extend(mod.env);
@@ -2208,12 +2227,12 @@
         return flatten(res[0].token.inner);
     }
 
-    function expandModule(stx, moduleContexts) {
+    function expandModule(stx, moduleContexts, options) {
         moduleContexts = moduleContexts || [];
         maxExpands = Infinity;
         expandCount = 0;
 
-        var context = makeExpanderContext();
+        var context = makeTopLevelExpanderContext(options);
         var modBody = syn.makeDelim("{}", stx, null);
         modBody = _.reduce(moduleContexts, function(acc, mod) {
             context.env.extend(mod.env);

--- a/src/sweet.js
+++ b/src/sweet.js
@@ -25,11 +25,26 @@
 
 (function (root, factory) {
     if (typeof exports === 'object') {
-        var path = require('path');
-        var fs   = require('fs');
+        var path        = require('path');
+        var fs          = require('fs');
+        var resolveSync = require('resolve/lib/sync');
+
         var lib  = path.join(path.dirname(fs.realpathSync(__filename)), "../macros");
 
         var stxcaseModule = fs.readFileSync(lib + "/stxcase.js", 'utf8');
+
+        var moduleCache = {};
+        var cwd = process.cwd();
+
+        function requireModule(id, filename) {
+            var basedir = filename ? path.dirname(filename) : cwd;
+            var key = basedir + '__sweet_js_key__' + filename;
+
+            if (!moduleCache[key]) {
+                moduleCache[key] = require(resolveSync(id, {basedir: basedir}));
+            }
+            return moduleCache[key];
+        }
 
         factory(exports,
                 require("underscore"),
@@ -39,7 +54,10 @@
                 stxcaseModule,
                 require("escodegen"),
                 require("escope"),
-                fs);
+                fs,
+                path,
+                resolveSync,
+                requireModule);
 
         // Alow require('./example') for an example.sjs file.
         require.extensions['.sjs'] = function(module, filename) {
@@ -55,7 +73,7 @@
                 './syntax',
                 'text!./stxcase.js'], factory);
     }
-}(this, function (exports, _, parser, expander, syn, stxcaseModule, gen, scope, fs) {
+}(this, function (exports, _, parser, expander, syn, stxcaseModule, gen, scope, fs, path, resolveSync, requireModule) {
     var codegen = gen || escodegen;
     var escope = scope || escope;
     var expand = makeExpand(expander.expand);
@@ -64,7 +82,7 @@
 
     function makeExpand(expandFn) {
         // fun (Str) -> [...CSyntax]
-        return function expand(code, modules, maxExpands) {
+        return function expand(code, modules, options) {
             var program, toString;
             modules = modules || [];
 
@@ -97,7 +115,7 @@
 
             var readTree = parser.read(source);
             try {
-                return expandFn(readTree, [stxcaseCtx].concat(modules), maxExpands);
+                return expandFn(readTree, [stxcaseCtx].concat(modules), options);
             } catch(err) {
                 if (err instanceof syn.MacroSyntaxError) {
                     throw new SyntaxError(syn.printSyntaxError(source, err));
@@ -109,14 +127,14 @@
     }
 
     // fun (Str, {}) -> AST
-    function parse(code, modules, maxExpands) {
+    function parse(code, modules, options) {
         if (code === "") {
             // old version of esprima doesn't play nice with the empty string
             // and loc/range info so until we can upgrade hack in a single space
             code = " ";
         }
 
-        return parser.parse(expand(code, modules, maxExpands));
+        return parser.parse(expand(code, modules, options));
     }
 
     // (Str, {sourceMap: ?Bool, filename: ?Str})
@@ -124,10 +142,11 @@
     function compile(code, options) {
         var output;
         options = options || {};
+        options.requireModule = options.requireModule || requireModule;
 
         var ast = parse(code, 
                         options.modules || [],
-                        options.maxExpands);
+                        options);
 
         if (options.readableNames) {
             ast = optimizeHygiene(ast);
@@ -156,15 +175,16 @@
         };
     }
 
-    function loadNodeModule(root, moduleName) {
-        var Module = module.constructor;
-        var mock = {
-            id: root + "/$sweet-loader.js",
-            filename: "$sweet-loader.js",
-            paths: /^\.\/|\.\./.test(root) ? [root] : Module._nodeModulePaths(root)
-        };
-        var path = Module._resolveFilename(moduleName, mock);
-        return expandModule(fs.readFileSync(path, "utf8"));
+    function loadNodeModule(root, moduleName, options) {
+        options = options || {};
+        if (moduleName[0] === '.') {
+            moduleName = path.resolve(root, moduleName)
+        }
+        var filename = resolveSync(moduleName, {basedir: root});
+        return expandModule(fs.readFileSync(filename, "utf8"), undefined, {
+            filename: moduleName,
+            requireModule: options.requireModule || requireModule
+        });
     }
 
     function optimizeHygiene(ast) {


### PR DESCRIPTION
Heavy WIP. Should be pulled on top of #227, just the latest commit is interesting actually.

Adds "import macros from ..." primitive macro which mimics a part of ES6 module
syntax and brings every exported macro from an external module into scope of the
current module.

```
import macros from "./id.sjs"

var x = id 42
```

At first, I wanted to implement just standard ES6 module syntax but the realized
that there's no way to differentiate between runtime module imports and
compile-time module imports.

Implemented as a primitive macro.