### PR TITLE
Detect and report hashbag as unsupported

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -265,7 +265,8 @@ parseYieldExpression: true
         ComprehensionRequiresBlock: 'Comprehension must have at least one block',
         ComprehensionError: 'Comprehension Error',
         EachNotAllowed: 'Each is not supported',
-        UnmatchedDelimiter: 'Unmatched Delimiter'
+        UnmatchedDelimiter: 'Unmatched Delimiter',
+        HashBang: 'HashBang interpreter directive is not supported'
     };
     // See also tools/generate-unicode-regex.py.
     Regex = {
@@ -4728,6 +4729,9 @@ parseYieldExpression: true
         }
         function _scanRegExp() {
             return attachComments(scanRegExp());
+        }
+        if (index === 2 && source.slice(index - 2, index + 1) === '#!/') {
+            throwError({}, Messages.HashBang);
         }
         skipComment();
         if (extra.comments.length > commentsLen) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -265,8 +265,7 @@ parseYieldExpression: true
         ComprehensionRequiresBlock: 'Comprehension must have at least one block',
         ComprehensionError: 'Comprehension Error',
         EachNotAllowed: 'Each is not supported',
-        UnmatchedDelimiter: 'Unmatched Delimiter',
-        HashBang: 'HashBang interpreter directive is not supported'
+        UnmatchedDelimiter: 'Unmatched Delimiter'
     };
     // See also tools/generate-unicode-regex.py.
     Regex = {
@@ -4729,9 +4728,6 @@ parseYieldExpression: true
         }
         function _scanRegExp() {
             return attachComments(scanRegExp());
-        }
-        if (index === 2 && source.slice(index - 2, index + 1) === '#!/') {
-            throwError({}, Messages.HashBang);
         }
         skipComment();
         if (extra.comments.length > commentsLen) {

--- a/lib/prepare_file.js
+++ b/lib/prepare_file.js
@@ -1,0 +1,36 @@
+/*
+  Copyright (C) 2014 Austin King <shout@ozten.com>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/*global exports:true*/
+
+// Pre-process source files (for sjs CLI only)
+module.exports = function(file) {
+  // Issue#341 - remove HashBang from files
+  if (file && file.length > 3 &&
+      file.substr(0, 3) === '#!/') {
+    var EOL = file.indexOf('\n');
+    return file.substring(EOL);
+  } else {
+    return file;
+  }
+};

--- a/lib/sjs.js
+++ b/lib/sjs.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var prepare = require('./prepare_file');
 var sweet = require('./sweet.js');
 var syn = require('./syntax.js');
 var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').argv;
@@ -27,6 +28,8 @@ exports.run = function () {
         console.log(require('optimist').help());
         return;
     }
+
+    file = prepare(file);
     var cwd = process.cwd();
     var modules = typeof argv.module === 'string' ? [argv.module] : argv.module;
     modules = (modules || []).map(function (path$2) {
@@ -41,7 +44,7 @@ exports.run = function () {
         };
     if (watch && outfile) {
         fs.watch(infile, function () {
-            file = fs.readFileSync(infile, 'utf8');
+            file = prepare(fs.readFileSync(infile, 'utf8'));
             try {
                 fs.writeFileSync(outfile, sweet.compile(file, options).code, 'utf8');
             } catch (e) {

--- a/lib/sjs.js
+++ b/lib/sjs.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+
 var prepare = require('./prepare_file');
 var sweet = require('./sweet.js');
 var syn = require('./syntax.js');
@@ -28,6 +29,7 @@ exports.run = function () {
         console.log(require('optimist').help());
         return;
     }
+
 
     file = prepare(file);
     var cwd = process.cwd();

--- a/test/fixtures/test_require/executable.sjs
+++ b/test/fixtures/test_require/executable.sjs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+process.stdout.write('Sweet');

--- a/test/test_executables.js
+++ b/test/test_executables.js
@@ -1,0 +1,13 @@
+var expect = require("expect.js");
+var path = require("path");
+
+describe('Loading executables does not die on HashBang', function() {
+
+  it('loads code from macros defined in imported module', function() {
+    process.argv = [ 'node', 'jsj', path.join(__dirname, './fixtures/test_require/executable.sjs')];
+    var sjs = require("../lib/sjs.js");
+    console.log(sjs);
+
+    sjs.run();
+  });
+});

--- a/test/test_executables.js
+++ b/test/test_executables.js
@@ -2,11 +2,10 @@ var expect = require("expect.js");
 var path = require("path");
 
 describe('Loading executables does not die on HashBang', function() {
-
-  it('loads code from macros defined in imported module', function() {
-    process.argv = [ 'node', 'jsj', path.join(__dirname, './fixtures/test_require/executable.sjs')];
+  it('Have CLI copy of sjs.js load an executable', function() {
+    // Mock out arguments for optimist to load our fixture
+    process.argv = [ 'node', 'some/bin/sjs', path.join(__dirname, './fixtures/test_require/executable.sjs')];
     var sjs = require("../lib/sjs.js");
-    console.log(sjs);
 
     sjs.run();
   });


### PR DESCRIPTION
If I run `sjs` over a NodeJS source which has `#!/usr/bin/env node` then I get the error

    Error: Line 1: Invalid regular expression

I wasn't able to find a clean way to remove the offending line from the source and continue parsing.

Perhaps throwing a more direct error message? This PR would instead give the error

    Error: Line 1: HashBang interpreter directive is not supported