### PR TITLE
Magic vars for repeaters

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -945,6 +945,18 @@
                                 return hasMatch(renv[pat]);
                             });
                             if (allHaveMatch) {
+                                renv.$$index = {
+                                    level: 0,
+                                    match: [syntax.makeValue(idx, bodyStx)]
+                                };
+                                renv.$$index1 = {
+                                    level: 0,
+                                    match: [syntax.makeValue(idx + 1, bodyStx)]
+                                };
+                                renv.$$length = {
+                                    level: 0,
+                                    match: [syntax.makeValue(repeatLength, bodyStx)]
+                                };
                                 restrictedEnv.push(renv);
                             }
                         });

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -1130,4 +1130,29 @@ describe("macro expander", function() {
         expect(res[0]).to.be(1);
         expect(res[1]).to.be(2);
     });
+
+    it("should allow magic vars in repeaters", function() {
+        macro m {
+            rule { ($t (,) ...) } => {
+              [$([$t, $$index, $$index1, $$length]) (,) ...]
+            }
+        }
+        expect(m(0, 1, 2)).to.eql([[0, 0, 1, 3],
+                                   [1, 1, 2, 3],
+                                   [2, 2, 3, 3]]);
+    });
+
+    it("should allow magic vars in nested repeaters", function() {
+        macro m {
+            rule { $(($t (,) ...)) ... } => {
+              [$([$$index, $$length, $([$$index, $$length, $t]) (,) ...]) (,) ...]
+            }
+        }
+        expect(m (1, 2, 3) (4, 5, 6)).to.eql([[0, 2, [0, 3, 1],
+                                                     [1, 3, 2],
+                                                     [2, 3, 3]],
+                                              [1, 2, [0, 3, 4],
+                                                     [1, 3, 5],
+                                                     [2, 3, 6]]]);
+    });
 });


### PR DESCRIPTION
This adds a few magic pattern vars that can only be referenced in repeaters: `$$index`, `$$index1` (plus 1), and `$$length`.