### PR TITLE
Recognize function declarations

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -5815,6 +5815,7 @@ parseYieldExpression: true
     exports.tokenize = tokenize;
     exports.read = read;
     exports.Token = Token;
+    exports.FnExprTokens = FnExprTokens;
 
     exports.setReadtable = setReadtable;
     exports.currentReadtable = currentReadtable;

--- a/test/test_macro_case.js
+++ b/test/test_macro_case.js
@@ -332,7 +332,14 @@ describe "procedural (syntax-case) macros" {
         }
 
         var f = ex {
-            function foo(x) {
+            // The naive implementation proposed in this changeset disables
+            // behavior that may be considered a feature. Specifically: macros
+            // that expand to named functions can be used in place of an
+            // expression or a statement.  Although this test is intended to
+            // exercise other code, it unintentionally leverages that
+            // functionality and must be updated to meet
+            // the new (more stringent) requirements.
+            function(x) {
                 macro arg {
                     rule {} => { x }
                 }

--- a/test/test_macro_hygiene.js
+++ b/test/test_macro_hygiene.js
@@ -367,6 +367,7 @@ describe "macro hygiene" {
             '    function foo() {',
             '        var i = 3;',
             '    }',
+            //'    +function foo() {};
             '}',
             'function bar() {',
             '    var i = 2;',
@@ -380,6 +381,9 @@ describe "macro hygiene" {
             '    function foo$2() {',
             '        var i$3 = 3;',
             '    }',
+            // The scoping mechanism should recognize that named function
+            // expressions do not modify the environment record of their scope.
+            //'    +function foo$2() {};
             '}',
             'function bar() {',
             '    var i$2 = 2;',


### PR DESCRIPTION
Currently, the `:expr` pattern matches function declarations as well as
function statements. Although I thought the fix would be simple, the underlying
bug is more far-reaching than I anticipated. I'd very much like to contribute
to this project, but I could really use a pointer or two in order to proceed.

Would anyone mind looking this over and offering suggestions?