### PR TITLE
Automatic Macro Refactoring (Macrofication)

### DIFF
--- a/browser/break.txt
+++ b/browser/break.txt
@@ -1,0 +1,9 @@
+let x = 0 in x
+
+-->
+
+inx x
+
+-->
+
+let x' = 0 in x

--- a/browser/editor.html
+++ b/browser/editor.html
@@ -208,11 +208,16 @@
         background: rgba(0,0,0,0.3);
         border-radius: 10px;
         box-shadow: 0 0 10px #000;
-        cursor: pointer;
         z-index: 4;
     }
     .replace pre {
         color: #268bd2;
+    }
+    .replace * {
+        background-color: rgba(0,0,0,0) !important;
+        cursor: pointer !important;
+        box-shadow: none !important;
+        -webkit-box-shadow: none !important;
     }
 
 </style>

--- a/browser/editor.html
+++ b/browser/editor.html
@@ -199,6 +199,22 @@
         text-align: center;
     }
 
+    .replace {
+        position: absolute;
+        width: 20em;
+        font-size: 10pt;
+        padding: 5px;
+        color: #aaa;
+        background: rgba(0,0,0,0.3);
+        border-radius: 10px;
+        box-shadow: 0 0 10px #000;
+        cursor: pointer;
+        z-index: 4;
+    }
+    .replace pre {
+        color: #268bd2;
+    }
+
 </style>
 </head>
 <body>

--- a/browser/editor.html
+++ b/browser/editor.html
@@ -233,11 +233,15 @@
                 <input checked id="ck-readable-names" name="ck-readable-names" type="checkbox"/>
                 <label for="ck-readable-names">readable names</label>
             </span>
-        </span>
-        <span class="align-left option cks">
             <span class="ck">
                 <input id="ck-auto-compile" name="ck-auto-compile" type="checkbox" value="compile"/>
                 <label for="ck-auto-compile">auto-compile</label>
+            </span>
+        </span>
+        <span class="align-left option cks">
+            <span class="ck">
+                <input id="ck-macrofy" name="ck-macrofy" type="checkbox" />
+                <label for="ck-macrofy">highlight macrofication</label>
             </span>
             <span class="ck">
                 <input id="ck-highlighting" name="ck-highlighting" type="checkbox" />

--- a/browser/scripts/editor.js
+++ b/browser/scripts/editor.js
@@ -126,6 +126,7 @@ candidates.
 candidates.
     combineLatest(mirrors.flatMap(editorCursor), concat.bind([])).
     flatMap(applyArgs(selectMacroficationHighlight)).
+    debounce(100).
     subscribe(applyArgs(popupMacrofication));
 
 return mirrors.connect() && documentReadyObs.connect();
@@ -877,19 +878,27 @@ function selectMacroficationHighlight(editor, name, highlights, cursor) {
 
 function popupMacrofication(editor, highlight) {
     var coords = editor.cursorCoords();
-    $('<div class="replace"></div>')
-        .css('left', coords.left)
-        .css('top', coords.top)
-        .css('display', 'none')
-        .append($('<span>Replace with macro?</span>'))
-        .append($('<pre class="cm-s-solarized">' + highlight.replacement + '</pre>'))
-        .click(function() {
+    var options = {
+        theme: 'solarized dark',
+        readOnly: 'nocursor',
+        lineNumbers: false,
+        scrollbarStyle: 'null'
+    };
+    var srcView = $('<textarea class="CodeMirror cm-s-solarized cm-s-dark">' + highlight.replacement + '</textarea>');
+    $('<div class="replace"></div>').
+        css('left', coords.left).
+        css('top', coords.top).
+        css('display', 'none').
+        append($('<span>Replace with macro?</span>')).
+        append(srcView).
+        click(function() {
             editor.removeOverlay('candidates');
             editor.setValue(highlight.replacedSrc);
             $(this).hide('fast', function() { $(this).remove(); });
-        })
-        .appendTo('#edit-box')
-        .show('fast');
+        }).
+        appendTo('#edit-box').
+        show('fast');
+    _.defer(function() { CodeMirror.fromTextArea(srcView[0], options) });
 }
 
 });

--- a/browser/scripts/editor.js
+++ b/browser/scripts/editor.js
@@ -14,7 +14,7 @@ requirejs.config({
     }
 });
 
-require(["./sweet", "./syntax", "./parser", "./source-map", "./rx.jquery.min", "./rx.dom.compat.min"], function (sweet, syn, parser, srcmap, Rx) {
+require(["./sweet", "./syntax", "./parser", "./source-map", './reverse', "./rx.jquery.min", "./rx.dom.compat.min"], function (sweet, syn, parser, srcmap, reverse, Rx) {
 
 srcmap = srcmap || sourceMap;
 /**
@@ -112,6 +112,11 @@ mirrors
     // Apply the highlights for each codeMirror instance
     // as CodeMirror overlays.
     .subscribe(applyArgs(commitHighlights));
+
+// highlight macro candidates
+mirrors.flatMap(editorChange).
+    map(macroCandidates).
+    subscribe(applyArgs(commitHighlights));
 
 return mirrors.connect() && documentReadyObs.connect();
 
@@ -420,6 +425,13 @@ function selectCompileType(
                 .scan(readableNames.is(":checked"), Rx.helpers.not)
                 .startWith(readableNames.is(":checked"));
         }),
+
+        reverseChangeObs      = Rx.Observable.defer(function() {
+            return readableNames
+                .changeAsObservable()
+                .scan(readableNames.is(":checked"), Rx.helpers.not)
+                .startWith(readableNames.is(":checked"));
+        }),
         
         highlightChangeObs  = Rx.Observable.defer(function() {
             return highlight
@@ -642,8 +654,8 @@ function selectEditorHightlights(editor, output, result, cursor) {
     // only show macro highlights if cursor on macro name
     if (!sourcemap || !macro || !logs.length) {
         return [
-            [editor, []],
-            [output, []]
+            [editor, "macro", []],
+            [output, "macro", []]
         ];
     }
     
@@ -651,50 +663,18 @@ function selectEditorHightlights(editor, output, result, cursor) {
         mappings   = [],
         outHighlights,
         srcHighlights = [
-                mapTokensToHighlights(macro.next, true),
-                mapTokensToHighlights(macro.name, false, true)
-            ].concat(macro.matchedTokens.map(mapTokensToHighlights));
+                tokenToHighlight(macro.next, true),
+                tokenToHighlight(macro.name, false, true)
+            ].concat(macro.matchedTokens.map(tokenToHighlight));
     
     consumer.eachMapping(function(mapping) { mappings.push(mapping); });
     
     outHighlights = mappings.reduce(reduceMappingsToOutHighlights, [undefined, []]).pop();
     
     return [
-        [editor, slice.call(srcHighlights, 1)],
-        [output, outHighlights]
+        [editor, "macro", slice.call(srcHighlights, 1)],
+        [output, "macro", outHighlights]
     ];
-    
-    function mapTokensToHighlights(token, isStart, isName) {
-        var highlight = (token.type === parser.Token.Delimiter) ?
-            {
-                start: {
-                    line: token.startLineNumber,
-                    column: token.startRange[0] - token.startLineStart
-                },
-                end: {
-                    line: token.endLineNumber,
-                    column: token.endRange[1] - token.endLineStart
-                }
-            } :
-            {
-                start: {
-                    line: token.lineNumber,
-                    column: token.range[0] - token.lineStart
-                },
-                end: {
-                    line: token.lineNumber,
-                    column: token.range[1] - token.lineStart
-                }
-            };
-        
-        if(isStart === true) {
-            highlight.end = highlight.start;
-        }
-        if(isName === true) {
-            highlight.name = true;
-        }
-        return highlight;
-    }
     
     function reduceMappingsToOutHighlights(tuple, mapping) {
         
@@ -739,8 +719,8 @@ function selectEditorHightlights(editor, output, result, cursor) {
     }
 }
 
-function commitHighlights(editor, highlights) {
-    editor.removeOverlay("macro");
+function commitHighlights(editor, name, highlights) {
+    editor.removeOverlay(name);
     if (highlights.length === 0) return;
     highlights.sort(function(a, b) {
         if (a.start.line < b.start.line) return -1;
@@ -749,7 +729,7 @@ function commitHighlights(editor, highlights) {
     });
     var line = 0, currentIdx = 0;
     editor.addOverlay({
-        name: "macro",
+        name: name,
         token: function(stream) {
             if (stream.sol()) line++;
             if (currentIdx >= highlights.length) { // no more highlights
@@ -779,10 +759,79 @@ function commitHighlights(editor, highlights) {
                 current.start.column = 0;
                 stream.skipToEnd();
             }
-            return current.name ? "macro-name" : "macro";
+            return current.name ? name + "-name" : name;
         },
         blankLine: function() { line++; }
     });
+}
+
+function editorChange(editors) {
+    return Rx.Observable.fromEvent(editors[0], "change").
+        debounce(750).
+        startWith(0).
+        map(function() { return editors[0]; });
+}
+
+function macroCandidates(editor) {
+    var highlights = [];
+    try {
+        var highlights = reverse.findReverseMatches(editor.getValue()).
+            map(function(match) {
+                var start = useOriginalLoc(match.matchedTokens[0].token);
+                var end = useOriginalLoc(_.last(match.matchedTokens).token);
+                return {
+                    start: tokenToHighlight(start).start,
+                    end: tokenToHighlight(end).end,
+                    match: match
+                }
+            });
+    } catch(e) { }
+    return [editor, "candidate", highlights];
+
+    function useOriginalLoc(token) {
+        var props = ['lineStart', 'lineNumber', 'range', 'startLineStart',
+            'startLineNumber', 'startRange', 'endLineStart',
+            'endLineNumber', 'endRange'];
+        var obj = _.clone(token);
+        for (var i = 0; i < props.length; i++) {
+            if (obj.hasOwnProperty('sm_' + props[i])) {
+                obj[props[i]] = obj['sm_' + props[i]];
+            }
+        }
+        return obj;
+    }
+}
+
+function tokenToHighlight(token, isStart, isName) {
+    var highlight = (token.type === parser.Token.Delimiter) ?
+        {
+            start: {
+                line: token.startLineNumber,
+                column: token.startRange[0] - token.startLineStart
+            },
+            end: {
+                line: token.endLineNumber,
+                column: token.endRange[1] - token.endLineStart
+            }
+        } :
+        {
+            start: {
+                line: token.lineNumber,
+                column: token.range[0] - token.lineStart
+            },
+            end: {
+                line: token.lineNumber,
+                column: token.range[1] - token.lineStart
+            }
+        };
+
+    if(isStart === true) {
+        highlight.end = highlight.start;
+    }
+    if(isName === true) {
+        highlight.name = true;
+    }
+    return highlight;
 }
 
 });

--- a/browser/scripts/expander.js
+++ b/browser/scripts/expander.js
@@ -2552,6 +2552,7 @@
     exports$2.enforest = enforest;
     exports$2.expand = expandTopLevel;
     exports$2.expandModule = expandModule;
+    exports$2.flatten = flatten;
     exports$2.resolve = resolve;
     exports$2.get_expression = get_expression;
     exports$2.getName = getName;

--- a/browser/scripts/expander.js
+++ b/browser/scripts/expander.js
@@ -2553,6 +2553,7 @@
     exports$2.expand = expandTopLevel;
     exports$2.expandModule = expandModule;
     exports$2.flatten = flatten;
+    exports$2.adjustLineContext = adjustLineContext;
     exports$2.resolve = resolve;
     exports$2.get_expression = get_expression;
     exports$2.getName = getName;

--- a/browser/scripts/patterns.js
+++ b/browser/scripts/patterns.js
@@ -348,7 +348,7 @@
             patternEnv: patternEnv
         };
     }
-    function matchPatterns(patterns, stx, context, topLevel) {
+    function matchPatterns(patterns, stx, context, topLevel, patternEnv) {
         // topLevel lets us know if the patterns are on the top level or nested inside
         // a delimiter:
         //     case $topLevel (,) ... => { }
@@ -365,7 +365,7 @@
         // and the other is the pattern environment (patternEnv) that maps
         // patterns in a macro case to syntax.
         var result = [];
-        var patternEnv = {};
+        patternEnv = patternEnv || {};
         var match;
         var pattern;
         var rest = stx;
@@ -549,7 +549,7 @@
                     success = false;
                     rest = stx;
                 }
-            } else if (patternEnv[pattern.value] && patternEnv[pattern.value].level === 0) {
+            } else if (patternEnv[pattern.value] && patternEnv[pattern.value].match && patternEnv[pattern.value].level === 0) {
                 var prev = patternEnv[pattern.value].match;
                 while (prev.length === 1 && pattern.class === 'expr' && prev[0].token.type === parser.Token.Delimiter && prev[0].token.value === '()') {
                     prev = prev[0].token.inner;
@@ -568,9 +568,11 @@
                 };
                 if (// push the match onto this value's slot in the environment
                     pattern.repeat) {
-                    if (patternEnv[pattern.value] && success) {
+                    if (patternEnv[pattern.value] && patternEnv[pattern.value].level !== 1) {
+                        success = false;
+                    } else if (patternEnv[pattern.value] && patternEnv[pattern.value].match && success) {
                         patternEnv[pattern.value].match.push(matchEnv);
-                    } else if (patternEnv[pattern.value] === undefined) {
+                    } else if (patternEnv[pattern.value] === undefined || patternEnv[pattern.value].match === undefined) {
                         // initialize if necessary
                         patternEnv[pattern.value] = {
                             level: 1,
@@ -592,7 +594,7 @@
     }
     function copyPatternEnv(toEnv, fromEnv, topLevel) {
         _.forEach(fromEnv, function (patternVal, patternKey) {
-            if (!toEnv[patternKey]) {
+            if (!toEnv[patternKey] || !toEnv[patternKey].match) {
                 toEnv[patternKey] = {
                     level: patternVal.level + 1,
                     match: [patternVal],
@@ -635,7 +637,10 @@
             }
         } else {
             if (// match a group with a group by element-wise comparison
-                // (special case for empty match resulting from zero repitition)
+                // (special case for uninitialized match
+                !toMatch.match)
+                return true;
+            if (// (special case for empty match resulting from zero repitition)
                 fromMatch.match.length > 0 && fromMatch.match.length !== toMatch.match.length)
                 return;
             for (var i = 0; i < fromMatch.match.length; i++) {
@@ -649,17 +654,26 @@
     function isEquivPatternEnv(toEnv, fromEnv, repeat, prefix) {
         return _.all(fromEnv, function (patternVal, patternKey) {
             var patternName = prefix + patternKey;
-            if (_.has(toEnv, patternName)) {
+            if (!_.has(toEnv, patternName))
+                return true;
+            var fromVal = patternVal;
+            if (repeat) {
+                var nextLevel = patternVal.level + 1;
                 if (// if repeat and also toEnv.repeat then you just
                     // compare levels
-                    repeat && toEnv[patternName].repeat) {
-                    return toEnv[patternName].level === patternVal.level + 1;
-                } else {
-                    return isEquivPatternEnvMatch(toEnv[patternName], patternVal);
+                    toEnv[patternName].repeat) {
+                    return toEnv[patternName].level === nextLevel;
                 }
+                fromVal = {
+                    level: nextLevel,
+                    match: [patternVal]
+                };
             }
-            return true;
+            return isEquivPatternEnvMatch(toEnv[patternName], fromVal);
         });
+    }
+    function decreaseLevel(match) {
+        return match.length === 0 ? [] : match[0].match;
     }
     function loadPatternEnv(toEnv, fromEnv, topLevel, repeat, prefix) {
         prefix = prefix || '';
@@ -670,16 +684,27 @@
             var patternName = prefix + patternKey;
             if (repeat) {
                 var nextLevel = patternVal.level + 1;
-                if (toEnv[patternName]) {
+                if (toEnv[patternName] && toEnv[patternName].match) {
                     if (toEnv[patternName].repeat) {
                         toEnv[patternName].match.push(patternVal);
                     }
                 } else {
+                    var match = [patternVal];
+                    var repMatch = true;
+                    if (toEnv[patternName]) {
+                        while (match.length > 0 && nextLevel > toEnv[patternName].level) {
+                            match = decreaseLevel(match);
+                            nextLevel--;
+                            repMatch = false;
+                        }
+                    }
                     toEnv[patternName] = {
                         level: nextLevel,
-                        match: [patternVal],
+                        match: match,
                         topLevel: topLevel,
-                        repeat: true
+                        // if there was a prior uninitialized match with a
+                        // lower level, then this is not just a repitition
+                        repeat: repMatch
                     };
                 }
             } else {

--- a/browser/scripts/patterns.js
+++ b/browser/scripts/patterns.js
@@ -609,6 +609,8 @@
             return;
         if (fromToken.type !== toToken.type)
             return;
+        if (fromToken.type === parser.Token.EOF)
+            return true;
         if (fromToken.value !== toToken.value)
             return;
         if (fromToken.type !== parser.Token.Delimiter)

--- a/browser/scripts/patterns.js
+++ b/browser/scripts/patterns.js
@@ -921,5 +921,6 @@
     exports$2.typeIsLiteral = typeIsLiteral;
     exports$2.cloneMatch = cloneMatch;
     exports$2.makeIdentityRule = makeIdentityRule;
+    exports$2.isEquivPatternEnvToken = isEquivPatternEnvToken;
 }));
 //# sourceMappingURL=patterns.js.map

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -25,12 +25,11 @@
 // DONE
 // support simple macro classes
 // get replacement
-//
-// TODO
 // check whether replacement compiles
 // do not match own macro definition
-// coalesce replacements
-// replace all
+//
+// TODO
+// command line interface
 // editor integration
 //
 // Future:
@@ -131,8 +130,9 @@
         this.pattern = name.concat(this.pattern);
         this.patternRule = patternModule.loadPattern(this.pattern);
         this.addClassesToExpansionPattern();
+        this.removeClassesFromPattern();
     }
-    MacroRule.prototype.addClassesToExpansionPattern = function () {
+    MacroRule.prototype.getSimpleClasses = function () {
         var env = {};
         foldReadTree(function (t, init, rest, path) {
             var tok = rest[0];
@@ -142,6 +142,10 @@
                 env[tok.value] = tok.class;
             }
         }, this.patternRule);
+        return env;
+    };
+    MacroRule.prototype.addClassesToExpansionPattern = function () {
+        var env = this.getSimpleClasses();
         foldReadTree(function (t, init, rest, path) {
             var tok = rest[0];
             if (!tok)
@@ -150,6 +154,21 @@
                 tok.class = env[tok.value];
             }
         }, this.expansionRule);
+    };
+    MacroRule.prototype.removeClassesFromPattern = function () {
+        var env = this.getSimpleClasses();
+        foldReadTree(function (t, init, rest, path) {
+            var tok = rest[0].token;
+            if (!tok)
+                return;
+            if (tok.type === parser.Token.Identifier && env[tok.value]) {
+                if (rest[1] && rest[1].token.value === ':') {
+                    var idx = path[path.length - 1];
+                    var stx = path[path.length - 2];
+                    stx.splice(idx + 1, 2);
+                }
+            }
+        }, this.pattern);
     };
     MacroRule.prototype.removeClasses = function (rest) {
         this.pattern = _(this.pattern).filter(function (token) {
@@ -185,7 +204,7 @@
         var newTree = replaceInTree(newStx, _.initial(path, 2));
         try {
             // this might fail with an exception
-            parser.parse(sweet.expandSyntax(newTree, []));
+            sweet.expandSyntax(newTree, []);
             return {
                 matchedTokens: _.initial(rest, res.rest.length),
                 replacement: syntax.prettyPrint(expander.flatten(rep)),
@@ -196,6 +215,7 @@
         }
     };
     function findReverseMatches(stx) {
+        stx = expander.adjustLineContext(stx, stx[0]);
         var macros = findMacros(stx);
         return foldReadTree(function (matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -49,9 +49,14 @@
         }
         var parentIdx = path.pop();
         var parentStx = path.pop();
-        var parentCopy = _.clone(parentStx[parentIdx]);
+        var parentCopy = Object.create(Object.getPrototypeOf(parentStx[parentIdx]));
+        for (var key in parentStx[parentIdx]) {
+            if (parentStx[parentIdx].hasOwnProperty(key)) {
+                parentCopy[key] = parentStx[parentIdx][key];
+            }
+        }
         parentCopy.token = _.clone(parentCopy.token);
-        parentCopy.token.inner = newstx;
+        parentCopy.token.inner = newStx;
         var newParentStx = _(parentStx).toArray();
         newParentStx[parentIdx] = parentCopy;
         return replaceInTree(newParentStx, path);
@@ -190,8 +195,8 @@
             rep,
             res.rest
         ], true);
-        var newTree = replaceInTree(newStx, _.initial(path, 2));
-        var prefix = src.slice(0, startRange(rest[0]));
+        var // var newTree = replaceInTree(newStx, _.initial(path, 2));
+        prefix = src.slice(0, startRange(rest[0]));
         var suffix = src.slice(Math.min(src.length, startRange(res.rest[0])));
         var repSrc = syntax.prettyPrint(expander.flatten(rep));
         var newSrc = prefix + repSrc + suffix;
@@ -214,7 +219,7 @@
         var stx = parser.read(src);
         stx = expander.adjustLineContext(stx, stx[0]);
         var macros = findMacros(src);
-        return foldReadTree(function (matches, init, rest, path) {
+        var res = foldReadTree(function (matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {
                 var match = macros[i].tryMatch(init, rest, path, src);
                 if (match)
@@ -222,6 +227,7 @@
             }
             return matches;
         }, stx, []);
+        return res;
     }
     exports$2.findMacros = findMacros;
     exports$2.findReverseMatches = findReverseMatches;

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -1,0 +1,75 @@
+/*
+  Copyright (C) 2015 Tim Disney <tim@disnet.me>
+
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+(function (root, factory) {
+    if (typeof exports === 'object') {
+        // CommonJS
+        factory(exports, require('underscore'), require('./parser'), require('./patterns'), require('escodegen'));
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([
+            'exports',
+            'underscore',
+            'parser',
+            'syntax',
+            'scopedEval',
+            'patterns',
+            'escodegen'
+        ], factory);
+    }
+}(this, function (exports$2, _, parser, patternModule, gen) {
+    'use strict';
+    // escodegen still doesn't quite support AMD: https://github.com/Constellation/escodegen/issues/115
+    var codegen = typeof escodegen !== 'undefined' ? escodegen : gen;
+    var rulePatternSrc = 'rule { $p ... } => { $e ... }';
+    var rulePattern = _.initial(patternModule.loadPattern(parser.read(rulePatternSrc)));
+    // Pre-order traversal of read tree, provides rest tokens at each step
+    //
+    // fn :: a -> Token -> a
+    // stx :: [Token] (can be nested)
+    // initial :: a
+    function foldReadTree(fn, stx, initial) {
+        var current = initial;
+        for (var i = 0; i < stx.length; i++) {
+            current = fn(current, stx.slice(i));
+            if (stx[i].token.type === parser.Token.Delimiter) {
+                current = foldReadTree(fn, stx[i].token.inner, current);
+            }
+        }
+        return current;
+    }
+    function findMacroRules(stx) {
+        return foldReadTree(function (macros, rest) {
+            var res = patternModule.matchPatterns(rulePattern, rest, { env: {} });
+            if (res.success)
+                macros.push({
+                    pattern: res.patternEnv['$p'],
+                    expansion: res.patternEnv['$e']
+                });
+            return macros;
+        }, stx, []);
+    }
+    exports$2.findMacroRules = findMacroRules;
+}));
+//# sourceMappingURL=reverse.js.map

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -104,7 +104,8 @@
         newParentStx[parentIdx] = parentCopy;
         return replaceInTree(newParentStx, path);
     }
-    function findMacros(stx) {
+    function findMacros(src) {
+        var stx = parser.read(src);
         return foldReadTree(function (macros, init, rest, path) {
             var res = patternModule.matchPatterns(macroPattern, rest, { env: {} }, true);
             if (res.success) {
@@ -174,27 +175,39 @@
         this.pattern = _(this.pattern).filter(function (token) {
         });
     };
-    MacroRule.prototype.isInMacro = function (token) {
-        var range = token.range;
+    function startRange(token) {
+        if (!token)
+            return 9999999999;
+        if (token.token)
+            token = token.token;
         if (token.type === parser.Token.Delimiter) {
-            range = [
-                token.startRange[0],
-                token.endRange[1]
-            ];
+            return token.startRange[0];
         }
-        var firstTok = this.pattern[0].token;
-        var start = firstTok.type === parser.Token.Delimiter ? firstTok.startRange[0] : firstTok.range[0];
-        var lastTok = _.last(this.expansion).token;
-        var end = lastTok.type === parser.Token.Delimiter ? lastTok.endRange[1] : lastTok.range[1];
-        return range[1] >= start && range[0] <= end;
+        return token.range[0];
+    }
+    function endRange(token) {
+        if (!token)
+            return 0;
+        if (token.token)
+            token = token.token;
+        if (token.type === parser.Token.Delimiter) {
+            return token.endRange[1];
+        }
+        return token.range[1];
+    }
+    MacroRule.prototype.isInMacro = function (token) {
+        var start = startRange(this.pattern[0]);
+        var end = endRange(_.last(this.expansion));
+        return endRange(token) >= start && startRange(token) <= end;
     };
-    MacroRule.prototype.tryMatch = function (init, rest, path) {
+    MacroRule.prototype.tryMatch = function (init, rest, path, src) {
         var c = { env: {} };
-        if (rest.length === 0 || this.isInMacro(rest[0].token))
+        if (rest.length === 0 || this.isInMacro(rest[0]))
             return;
         var res = patternModule.matchPatterns(this.expansionRule, rest, c, true);
         if (!res.success || rest.length === res.rest.length)
             return;
+        var matched = _.initial(rest, res.rest.length);
         var rep = patternModule.transcribe(this.pattern, 0, res.patternEnv);
         var newStx = _.flatten([
                 init,
@@ -202,24 +215,29 @@
                 res.rest
             ], true);
         var newTree = replaceInTree(newStx, _.initial(path, 2));
+        var prefix = src.slice(0, startRange(rest[0]));
+        var suffix = src.slice(Math.min(src.length, startRange(res.rest[0])));
+        var repSrc = syntax.prettyPrint(expander.flatten(rep));
         try {
             // this might fail with an exception
             sweet.expandSyntax(newTree, []);
             return {
-                matchedTokens: _.initial(rest, res.rest.length),
-                replacement: syntax.prettyPrint(expander.flatten(rep)),
-                replacedSrc: syntax.prettyPrint(expander.flatten(newTree))
+                matchedTokens: matched,
+                matchedSrc: syntax.prettyPrint(expander.flatten(matched)),
+                replacement: repSrc,
+                replacedSrc: prefix + repSrc + suffix
             };
         } catch (e) {
             return;
         }
     };
-    function findReverseMatches(stx) {
+    function findReverseMatches(src) {
+        var stx = parser.read(src);
         stx = expander.adjustLineContext(stx, stx[0]);
-        var macros = findMacros(stx);
+        var macros = findMacros(src);
         return foldReadTree(function (matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {
-                var match = macros[i].tryMatch(init, rest, path);
+                var match = macros[i].tryMatch(init, rest, path, src);
                 if (match)
                     matches.push(match);
             }

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -68,21 +68,20 @@
             if (res.success) {
                 var name = patternModule.transcribe(expandN, 0, res.patternEnv);
                 var con = patternModule.transcribe(expandE, 0, res.patternEnv);
-                return macros.concat(findMacroRules(name, con, stx));
+                return macros.concat(findMacroRules(name, con));
             }
             return macros;
         }, stx, []);
     }
-    function findMacroRules(name, m, stx) {
+    function findMacroRules(name, m) {
         return foldReadTree(function (macros, init, rest, path) {
             var res = patternModule.matchPatterns(rulePattern, rest, { env: {} }, true);
             if (res.success)
-                macros.push(new MacroRule(name, res.patternEnv, stx));
+                macros.push(new MacroRule(name, res.patternEnv));
             return macros;
         }, m, []);
     }
-    function MacroRule(name, patternEnv, stx) {
-        this.compUnit = { inner: stx };
+    function MacroRule(name, patternEnv) {
         this.expansion = patternModule.transcribe(expandE, 0, patternEnv);
         this.expansionRule = patternModule.loadPattern(this.expansion);
         this.pattern = patternModule.transcribe(expandP, 0, patternEnv);
@@ -132,7 +131,7 @@
     };
     function startRange(token) {
         if (!token)
-            return 9999999999;
+            return Number.MAX_VALUE;
         if (token.token)
             token = token.token;
         if (token.type === parser.Token.Delimiter) {
@@ -176,7 +175,7 @@
             }
         }, this.patternRule);
     };
-    MacroRule.prototype.tryMatch = function (init, rest, path, src) {
+    MacroRule.prototype.tryMatch = function (init, rest, path, src, expanded) {
         var c = { env: {} };
         if (rest.length === 0 || this.isInMacro(rest[0]))
             return;
@@ -202,9 +201,11 @@
         var newSrc = prefix + repSrc + suffix;
         try {
             var // this might fail with an exception
-            expanded = sweet.expand(newSrc);
-            var newCompUnit = { inner: expanded };
-            if (patternModule.isEquivPatternEnvToken(newCompUnit, this.compUnit)) {
+            newExpanded = {
+                inner: sweet.expand(newSrc),
+                type: parser.Token.Delimiter
+            };
+            if (patternModule.isEquivPatternEnvToken(expanded, newExpanded)) {
                 return {
                     matchedTokens: matched,
                     matchedSrc: syntax.prettyPrint(expander.flatten(matched)),
@@ -219,9 +220,13 @@
         var stx = parser.read(src);
         stx = expander.adjustLineContext(stx, stx[0]);
         var macros = findMacros(src);
+        var expanded = {
+            inner: sweet.expand(src),
+            type: parser.Token.Delimiter
+        };
         var res = foldReadTree(function (matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {
-                var match = macros[i].tryMatch(init, rest, path, src);
+                var match = macros[i].tryMatch(init, rest, path, src, expanded);
                 if (match)
                     matches.push(match);
             }

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -1,27 +1,3 @@
-/*
-  Copyright (C) 2015 Tim Disney <tim@disnet.me>
-
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
-  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 (function (root, factory) {
     if (typeof exports === 'object') {
         // CommonJS
@@ -48,11 +24,6 @@
     var expandN = _.initial(parser.read('$n'));
     var expandP = _.initial(parser.read('$p...'));
     var expandE = _.initial(parser.read('$e...'));
-    // Pre-order traversal of read tree, provides rest tokens at each step
-    //
-    // fn :: a -> Token -> a
-    // stx :: [Token] (can be nested)
-    // initial :: a
     function foldReadTree(fn, stx, initial, path) {
         var current = initial;
         if (!path) {
@@ -72,7 +43,6 @@
         path.pop();
         return current;
     }
-    // create a new tree by walking the path up and replacing nodes
     function replaceInTree(newStx, path) {
         if (path.length === 0) {
             return newStx;

--- a/browser/scripts/reverse.js
+++ b/browser/scripts/reverse.js
@@ -22,9 +22,11 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-// TODO
+// DONE
 // support simple macro classes
 // get replacement
+//
+// TODO
 // check whether replacement compiles
 // do not match own macro definition
 // coalesce replacements
@@ -40,7 +42,7 @@
 (function (root, factory) {
     if (typeof exports === 'object') {
         // CommonJS
-        factory(exports, require('underscore'), require('./parser'), require('./patterns'), require('./syntax'), require('escodegen'));
+        factory(exports, require('underscore'), require('./parser'), require('./patterns'), require('./syntax'), require('./expander'), require('escodegen'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define([
@@ -53,7 +55,7 @@
             'escodegen'
         ], factory);
     }
-}(this, function (exports$2, _, parser, patternModule, syntax, gen) {
+}(this, function (exports$2, _, parser, patternModule, syntax, expander, gen) {
     'use strict';
     // escodegen still doesn't quite support AMD: https://github.com/Constellation/escodegen/issues/115
     var codegen = typeof escodegen !== 'undefined' ? escodegen : gen;
@@ -136,11 +138,11 @@
         var res = patternModule.matchPatterns(this.expansionRule, rest, c, true);
         if (!res.success || rest.length === res.rest.length)
             return;
-        var rep = syntax.prettyPrint(syntax.joinSyntaxArray(patternModule.transcribe(this.pattern, 0, res.patternEnv)));
+        var rep = expander.flatten(patternModule.transcribe(this.pattern, 0, res.patternEnv));
         return {
             matchedTokens: _.initial(rest, res.rest.length),
             replacement: rep,
-            replacementSrc: codegen.generate(rep)
+            replacementSrc: syntax.prettyPrint(rep)
         };
     };
     function findReverseMatches(stx) {

--- a/browser/scripts/sjs.js
+++ b/browser/scripts/sjs.js
@@ -4,7 +4,7 @@ var pkg = require('../package.json');
 var sweet = require('./sweet.js');
 var syn = require('./syntax.js');
 var rev = require('./reverse');
-var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').boolean('reverse').describe('reverse', 'finds possible locations for macro usage').argv;
+var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').boolean('refactor').describe('refactor', 'macrofy the input by finding possible locations for macro invocations').argv;
 exports.run = function () {
     if (argv.version) {
         return console.log('Sweet.js version: ' + pkg.version);
@@ -21,7 +21,7 @@ exports.run = function () {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
-    var reverse = argv.reverse;
+    var refactor = argv.refactor;
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }
@@ -63,11 +63,10 @@ exports.run = function () {
             fs.writeFileSync(outfile, sweet.compile(file, options).code, 'utf8');
         }
     }
-    if (reverse) {
+    if (refactor) {
         var match = rev.findReverseMatches(file)[0];
         if (!match)
-            return console.log('no reverse matches found');
-        console.log('replaced\n\n' + match.matchedSrc + '\nwith\n\n' + match.replacement);
+            return console.log('no macorfication candidates found');
         if (outfile) {
             fs.writeFileSync(outfile, match.replacedSrc);
         } else {

--- a/browser/scripts/sjs.js
+++ b/browser/scripts/sjs.js
@@ -3,7 +3,8 @@ var path = require('path');
 var pkg = require('../package.json');
 var sweet = require('./sweet.js');
 var syn = require('./syntax.js');
-var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').argv;
+var rev = require('./reverse');
+var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').boolean('reverse').describe('reverse', 'finds possible locations for macro usage').argv;
 exports.run = function () {
     if (argv.version) {
         return console.log('Sweet.js version: ' + pkg.version);
@@ -20,6 +21,7 @@ exports.run = function () {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
+    var reverse = argv['reverse'];
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }
@@ -61,7 +63,17 @@ exports.run = function () {
             fs.writeFileSync(outfile, sweet.compile(file, options).code, 'utf8');
         }
     }
-    if (watch && outfile) {
+    if (reverse) {
+        var match = rev.findReverseMatches(file)[0];
+        if (!match)
+            return console.log('no reverse matches found');
+        console.log('replaced\n\n' + match.matchedSrc + '\nwith\n\n' + match.replacement);
+        if (outfile) {
+            fs.writeFileSync(outfile, match.replacedSrc);
+        } else {
+            console.log('\n\n' + match.replacedSrc);
+        }
+    } else if (watch && outfile) {
         fs.watch(infile, function () {
             file = fs.readFileSync(infile, 'utf8');
             try {

--- a/browser/scripts/sjs.js
+++ b/browser/scripts/sjs.js
@@ -21,7 +21,7 @@ exports.run = function () {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
-    var reverse = argv['reverse'];
+    var reverse = argv.reverse;
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }

--- a/browser/solarized.css
+++ b/browser/solarized.css
@@ -214,3 +214,6 @@ View-port and gutter both get little noise background to give it a real feel.
 .cm-s-solarized .cm-macro-name {
     border-bottom: 2px solid rgb(192,0,192);
 }
+.cm-s-solarized .cm-candidate {
+    background-color: rgba(0,96,0,0.3);
+}

--- a/lib/expander.js
+++ b/lib/expander.js
@@ -2552,6 +2552,8 @@
     exports$2.enforest = enforest;
     exports$2.expand = expandTopLevel;
     exports$2.expandModule = expandModule;
+    exports$2.flatten = flatten;
+    exports$2.adjustLineContext = adjustLineContext;
     exports$2.resolve = resolve;
     exports$2.get_expression = get_expression;
     exports$2.getName = getName;

--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -348,7 +348,7 @@
             patternEnv: patternEnv
         };
     }
-    function matchPatterns(patterns, stx, context, topLevel) {
+    function matchPatterns(patterns, stx, context, topLevel, patternEnv) {
         // topLevel lets us know if the patterns are on the top level or nested inside
         // a delimiter:
         //     case $topLevel (,) ... => { }
@@ -365,7 +365,7 @@
         // and the other is the pattern environment (patternEnv) that maps
         // patterns in a macro case to syntax.
         var result = [];
-        var patternEnv = {};
+        patternEnv = patternEnv || {};
         var match;
         var pattern;
         var rest = stx;
@@ -549,7 +549,7 @@
                     success = false;
                     rest = stx;
                 }
-            } else if (patternEnv[pattern.value] && patternEnv[pattern.value].level === 0) {
+            } else if (patternEnv[pattern.value] && patternEnv[pattern.value].match && patternEnv[pattern.value].level === 0) {
                 var prev = patternEnv[pattern.value].match;
                 while (prev.length === 1 && pattern.class === 'expr' && prev[0].token.type === parser.Token.Delimiter && prev[0].token.value === '()') {
                     prev = prev[0].token.inner;
@@ -568,9 +568,11 @@
                 };
                 if (// push the match onto this value's slot in the environment
                     pattern.repeat) {
-                    if (patternEnv[pattern.value] && success) {
+                    if (patternEnv[pattern.value] && patternEnv[pattern.value].level !== 1) {
+                        success = false;
+                    } else if (patternEnv[pattern.value] && patternEnv[pattern.value].match && success) {
                         patternEnv[pattern.value].match.push(matchEnv);
-                    } else if (patternEnv[pattern.value] === undefined) {
+                    } else if (patternEnv[pattern.value] === undefined || patternEnv[pattern.value].match === undefined) {
                         // initialize if necessary
                         patternEnv[pattern.value] = {
                             level: 1,
@@ -592,7 +594,7 @@
     }
     function copyPatternEnv(toEnv, fromEnv, topLevel) {
         _.forEach(fromEnv, function (patternVal, patternKey) {
-            if (!toEnv[patternKey]) {
+            if (!toEnv[patternKey] || !toEnv[patternKey].match) {
                 toEnv[patternKey] = {
                     level: patternVal.level + 1,
                     match: [patternVal],
@@ -635,7 +637,10 @@
             }
         } else {
             if (// match a group with a group by element-wise comparison
-                // (special case for empty match resulting from zero repitition)
+                // (special case for uninitialized match
+                !toMatch.match)
+                return true;
+            if (// (special case for empty match resulting from zero repitition)
                 fromMatch.match.length > 0 && fromMatch.match.length !== toMatch.match.length)
                 return;
             for (var i = 0; i < fromMatch.match.length; i++) {
@@ -649,17 +654,26 @@
     function isEquivPatternEnv(toEnv, fromEnv, repeat, prefix) {
         return _.all(fromEnv, function (patternVal, patternKey) {
             var patternName = prefix + patternKey;
-            if (_.has(toEnv, patternName)) {
+            if (!_.has(toEnv, patternName))
+                return true;
+            var fromVal = patternVal;
+            if (repeat) {
+                var nextLevel = patternVal.level + 1;
                 if (// if repeat and also toEnv.repeat then you just
                     // compare levels
-                    repeat && toEnv[patternName].repeat) {
-                    return toEnv[patternName].level === patternVal.level + 1;
-                } else {
-                    return isEquivPatternEnvMatch(toEnv[patternName], patternVal);
+                    toEnv[patternName].repeat) {
+                    return toEnv[patternName].level === nextLevel;
                 }
+                fromVal = {
+                    level: nextLevel,
+                    match: [patternVal]
+                };
             }
-            return true;
+            return isEquivPatternEnvMatch(toEnv[patternName], fromVal);
         });
+    }
+    function decreaseLevel(match) {
+        return match.length === 0 ? [] : match[0].match;
     }
     function loadPatternEnv(toEnv, fromEnv, topLevel, repeat, prefix) {
         prefix = prefix || '';
@@ -670,16 +684,27 @@
             var patternName = prefix + patternKey;
             if (repeat) {
                 var nextLevel = patternVal.level + 1;
-                if (toEnv[patternName]) {
+                if (toEnv[patternName] && toEnv[patternName].match) {
                     if (toEnv[patternName].repeat) {
                         toEnv[patternName].match.push(patternVal);
                     }
                 } else {
+                    var match = [patternVal];
+                    var repMatch = true;
+                    if (toEnv[patternName]) {
+                        while (match.length > 0 && nextLevel > toEnv[patternName].level) {
+                            match = decreaseLevel(match);
+                            nextLevel--;
+                            repMatch = false;
+                        }
+                    }
                     toEnv[patternName] = {
                         level: nextLevel,
-                        match: [patternVal],
+                        match: match,
                         topLevel: topLevel,
-                        repeat: true
+                        // if there was a prior uninitialized match with a
+                        // lower level, then this is not just a repitition
+                        repeat: repMatch
                     };
                 }
             } else {

--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -609,6 +609,8 @@
             return;
         if (fromToken.type !== toToken.type)
             return;
+        if (fromToken.type === parser.Token.EOF)
+            return true;
         if (fromToken.value !== toToken.value)
             return;
         if (fromToken.type !== parser.Token.Delimiter)

--- a/lib/patterns.js
+++ b/lib/patterns.js
@@ -921,5 +921,6 @@
     exports$2.typeIsLiteral = typeIsLiteral;
     exports$2.cloneMatch = cloneMatch;
     exports$2.makeIdentityRule = makeIdentityRule;
+    exports$2.isEquivPatternEnvToken = isEquivPatternEnvToken;
 }));
 //# sourceMappingURL=patterns.js.map

--- a/lib/reverse.js
+++ b/lib/reverse.js
@@ -49,9 +49,14 @@
         }
         var parentIdx = path.pop();
         var parentStx = path.pop();
-        var parentCopy = _.clone(parentStx[parentIdx]);
+        var parentCopy = Object.create(Object.getPrototypeOf(parentStx[parentIdx]));
+        for (var key in parentStx[parentIdx]) {
+            if (parentStx[parentIdx].hasOwnProperty(key)) {
+                parentCopy[key] = parentStx[parentIdx][key];
+            }
+        }
         parentCopy.token = _.clone(parentCopy.token);
-        parentCopy.token.inner = newstx;
+        parentCopy.token.inner = newStx;
         var newParentStx = _(parentStx).toArray();
         newParentStx[parentIdx] = parentCopy;
         return replaceInTree(newParentStx, path);
@@ -190,8 +195,8 @@
             rep,
             res.rest
         ], true);
-        var newTree = replaceInTree(newStx, _.initial(path, 2));
-        var prefix = src.slice(0, startRange(rest[0]));
+        var // var newTree = replaceInTree(newStx, _.initial(path, 2));
+        prefix = src.slice(0, startRange(rest[0]));
         var suffix = src.slice(Math.min(src.length, startRange(res.rest[0])));
         var repSrc = syntax.prettyPrint(expander.flatten(rep));
         var newSrc = prefix + repSrc + suffix;
@@ -214,7 +219,7 @@
         var stx = parser.read(src);
         stx = expander.adjustLineContext(stx, stx[0]);
         var macros = findMacros(src);
-        return foldReadTree(function (matches, init, rest, path) {
+        var res = foldReadTree(function (matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {
                 var match = macros[i].tryMatch(init, rest, path, src);
                 if (match)
@@ -222,6 +227,7 @@
             }
             return matches;
         }, stx, []);
+        return res;
     }
     exports$2.findMacros = findMacros;
     exports$2.findReverseMatches = findReverseMatches;

--- a/lib/reverse.js
+++ b/lib/reverse.js
@@ -68,21 +68,20 @@
             if (res.success) {
                 var name = patternModule.transcribe(expandN, 0, res.patternEnv);
                 var con = patternModule.transcribe(expandE, 0, res.patternEnv);
-                return macros.concat(findMacroRules(name, con, stx));
+                return macros.concat(findMacroRules(name, con));
             }
             return macros;
         }, stx, []);
     }
-    function findMacroRules(name, m, stx) {
+    function findMacroRules(name, m) {
         return foldReadTree(function (macros, init, rest, path) {
             var res = patternModule.matchPatterns(rulePattern, rest, { env: {} }, true);
             if (res.success)
-                macros.push(new MacroRule(name, res.patternEnv, stx));
+                macros.push(new MacroRule(name, res.patternEnv));
             return macros;
         }, m, []);
     }
-    function MacroRule(name, patternEnv, stx) {
-        this.compUnit = { inner: stx };
+    function MacroRule(name, patternEnv) {
         this.expansion = patternModule.transcribe(expandE, 0, patternEnv);
         this.expansionRule = patternModule.loadPattern(this.expansion);
         this.pattern = patternModule.transcribe(expandP, 0, patternEnv);
@@ -132,7 +131,7 @@
     };
     function startRange(token) {
         if (!token)
-            return 9999999999;
+            return Number.MAX_VALUE;
         if (token.token)
             token = token.token;
         if (token.type === parser.Token.Delimiter) {
@@ -176,7 +175,7 @@
             }
         }, this.patternRule);
     };
-    MacroRule.prototype.tryMatch = function (init, rest, path, src) {
+    MacroRule.prototype.tryMatch = function (init, rest, path, src, expanded) {
         var c = { env: {} };
         if (rest.length === 0 || this.isInMacro(rest[0]))
             return;
@@ -202,9 +201,11 @@
         var newSrc = prefix + repSrc + suffix;
         try {
             var // this might fail with an exception
-            expanded = sweet.expand(newSrc);
-            var newCompUnit = { inner: expanded };
-            if (patternModule.isEquivPatternEnvToken(newCompUnit, this.compUnit)) {
+            newExpanded = {
+                inner: sweet.expand(newSrc),
+                type: parser.Token.Delimiter
+            };
+            if (patternModule.isEquivPatternEnvToken(expanded, newExpanded)) {
                 return {
                     matchedTokens: matched,
                     matchedSrc: syntax.prettyPrint(expander.flatten(matched)),
@@ -219,9 +220,13 @@
         var stx = parser.read(src);
         stx = expander.adjustLineContext(stx, stx[0]);
         var macros = findMacros(src);
+        var expanded = {
+            inner: sweet.expand(src),
+            type: parser.Token.Delimiter
+        };
         var res = foldReadTree(function (matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {
-                var match = macros[i].tryMatch(init, rest, path, src);
+                var match = macros[i].tryMatch(init, rest, path, src, expanded);
                 if (match)
                     matches.push(match);
             }

--- a/lib/reverse.js
+++ b/lib/reverse.js
@@ -1,27 +1,3 @@
-/*
-  Copyright (C) 2015 Tim Disney <tim@disnet.me>
-
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
-  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 (function (root, factory) {
     if (typeof exports === 'object') {
         // CommonJS
@@ -48,11 +24,6 @@
     var expandN = _.initial(parser.read('$n'));
     var expandP = _.initial(parser.read('$p...'));
     var expandE = _.initial(parser.read('$e...'));
-    // Pre-order traversal of read tree, provides rest tokens at each step
-    //
-    // fn :: a -> Token -> a
-    // stx :: [Token] (can be nested)
-    // initial :: a
     function foldReadTree(fn, stx, initial, path) {
         var current = initial;
         if (!path) {
@@ -72,7 +43,6 @@
         path.pop();
         return current;
     }
-    // create a new tree by walking the path up and replacing nodes
     function replaceInTree(newStx, path) {
         if (path.length === 0) {
             return newStx;

--- a/lib/sjs.js
+++ b/lib/sjs.js
@@ -4,7 +4,7 @@ var pkg = require('../package.json');
 var sweet = require('./sweet.js');
 var syn = require('./syntax.js');
 var rev = require('./reverse');
-var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').boolean('reverse').describe('reverse', 'finds possible locations for macro usage').argv;
+var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').boolean('refactor').describe('refactor', 'macrofy the input by finding possible locations for macro invocations').argv;
 exports.run = function () {
     if (argv.version) {
         return console.log('Sweet.js version: ' + pkg.version);
@@ -21,7 +21,7 @@ exports.run = function () {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
-    var reverse = argv.reverse;
+    var refactor = argv.refactor;
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }
@@ -63,11 +63,10 @@ exports.run = function () {
             fs.writeFileSync(outfile, sweet.compile(file, options).code, 'utf8');
         }
     }
-    if (reverse) {
+    if (refactor) {
         var match = rev.findReverseMatches(file)[0];
         if (!match)
-            return console.log('no reverse matches found');
-        console.log('replaced\n\n' + match.matchedSrc + '\nwith\n\n' + match.replacement);
+            return console.log('no macorfication candidates found');
         if (outfile) {
             fs.writeFileSync(outfile, match.replacedSrc);
         } else {

--- a/lib/sjs.js
+++ b/lib/sjs.js
@@ -3,7 +3,8 @@ var path = require('path');
 var pkg = require('../package.json');
 var sweet = require('./sweet.js');
 var syn = require('./syntax.js');
-var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').argv;
+var rev = require('./reverse');
+var argv = require('optimist').usage('Usage: sjs [options] path/to/file.js').alias('v', 'version').describe('v', 'Output version info').boolean('version').alias('o', 'output').describe('o', 'Output file path').alias('m', 'module').describe('m', 'use a module file for loading macro definitions. Use ./ or ../ for relative path otherwise looks up in installed npm packages').alias('w', 'watch').describe('w', 'watch a file').boolean('watch').alias('t', 'tokens').describe('t', 'just emit the expanded tokens without parsing an AST').alias('a', 'ast').describe('a', 'just emit the expanded AST').alias('p', 'no-parse').describe('p', 'print out the expanded result but do not run through the parser (or apply hygienic renamings)').boolean('no-parse').alias('s', 'stdin').describe('s', 'read from stdin').boolean('stdin').alias('c', 'sourcemap').describe('c', 'generate a sourcemap').boolean('sourcemap').alias('n', 'num-expands').describe('n', 'the maximum number of expands to perform').alias('h', 'step-hygiene').describe('h', 'display hygienic renames when stepping with "--num-expands"').alias('r', 'readable-names').describe('r', 'remove as many hygienic renames as possible (ES5 code only!)').boolean('readable-names').describe('format-indent', 'number of spaces for indentation').alias('l', 'load-readtable').describe('load-readtable', 'readtable module to install').boolean('reverse').describe('reverse', 'finds possible locations for macro usage').argv;
 exports.run = function () {
     if (argv.version) {
         return console.log('Sweet.js version: ' + pkg.version);
@@ -20,6 +21,7 @@ exports.run = function () {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
+    var reverse = argv['reverse'];
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }
@@ -61,7 +63,17 @@ exports.run = function () {
             fs.writeFileSync(outfile, sweet.compile(file, options).code, 'utf8');
         }
     }
-    if (watch && outfile) {
+    if (reverse) {
+        var match = rev.findReverseMatches(file)[0];
+        if (!match)
+            return console.log('no reverse matches found');
+        console.log('replaced\n\n' + match.matchedSrc + '\nwith\n\n' + match.replacement);
+        if (outfile) {
+            fs.writeFileSync(outfile, match.replacedSrc);
+        } else {
+            console.log('\n\n' + match.replacedSrc);
+        }
+    } else if (watch && outfile) {
         fs.watch(infile, function () {
             file = fs.readFileSync(infile, 'utf8');
             try {

--- a/lib/sjs.js
+++ b/lib/sjs.js
@@ -21,7 +21,7 @@ exports.run = function () {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
-    var reverse = argv['reverse'];
+    var reverse = argv.reverse;
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }

--- a/src/expander.js
+++ b/src/expander.js
@@ -2771,6 +2771,7 @@
     exports.expand = expandTopLevel;
     exports.expandModule = expandModule;
     exports.flatten = flatten;
+    exports.adjustLineContext = adjustLineContext;
 
     exports.resolve = resolve;
     exports.get_expression = get_expression;

--- a/src/expander.js
+++ b/src/expander.js
@@ -2770,6 +2770,7 @@
     exports.enforest = enforest;
     exports.expand = expandTopLevel;
     exports.expandModule = expandModule;
+    exports.flatten = flatten;
 
     exports.resolve = resolve;
     exports.get_expression = get_expression;

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -1134,4 +1134,5 @@
     exports.typeIsLiteral = typeIsLiteral;
     exports.cloneMatch = cloneMatch;
     exports.makeIdentityRule = makeIdentityRule;
+    exports.isEquivPatternEnvToken = isEquivPatternEnvToken;
 }))

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -433,7 +433,7 @@
 
     // attempt to match patterns against stx
     // ([...Pattern], [...Syntax], Env) -> { result: [...Syntax], rest: [...Syntax], patternEnv: PatternEnv }
-    function matchPatterns(patterns, stx, context, topLevel) {
+    function matchPatterns(patterns, stx, context, topLevel, patternEnv) {
         // topLevel lets us know if the patterns are on the top level or nested inside
         // a delimiter:
         //     case $topLevel (,) ... => { }
@@ -450,7 +450,7 @@
         // and the other is the pattern environment (patternEnv) that maps
         // patterns in a macro case to syntax.
         var result = [];
-        var patternEnv = {};
+        patternEnv = patternEnv || {};
 
         var match;
         var pattern;
@@ -689,7 +689,8 @@
                     rest = stx;
                 }
             } else if (patternEnv[pattern.value] &&
-                      (patternEnv[pattern.value].level === 0)) {
+                       patternEnv[pattern.value].match &&
+                       patternEnv[pattern.value].level === 0) {
                 var prev = patternEnv[pattern.value].match;
                 while (prev.length === 1 && pattern.class === "expr" &&
                     prev[0].token.type === parser.Token.Delimiter &&
@@ -711,9 +712,14 @@
 
                 // push the match onto this value's slot in the environment
                 if (pattern.repeat) {
-                    if (patternEnv[pattern.value] && success) {
+                    if (patternEnv[pattern.value] &&
+                        patternEnv[pattern.value].level !== 1) {
+                        success = false;
+                    } else if (patternEnv[pattern.value] &&
+                        patternEnv[pattern.value].match && success) {
                         patternEnv[pattern.value].match.push(matchEnv);
-                    } else if (patternEnv[pattern.value] === undefined){
+                    } else if (patternEnv[pattern.value] === undefined ||
+                               patternEnv[pattern.value].match === undefined){
                         // initialize if necessary
                         patternEnv[pattern.value] = {
                             level: 1,
@@ -742,7 +748,7 @@
 
     function copyPatternEnv(toEnv, fromEnv, topLevel) {
         _.forEach(fromEnv, function(patternVal, patternKey) {
-            if (!toEnv[patternKey]) {
+            if (!toEnv[patternKey] || !toEnv[patternKey].match) {
                 toEnv[patternKey] = {
                     level: patternVal.level + 1,
                     match: [patternVal],
@@ -784,6 +790,8 @@
             }
         } else {
             // match a group with a group by element-wise comparison
+            // (special case for uninitialized match
+            if (!toMatch.match) return true;
             // (special case for empty match resulting from zero repitition)
             if (fromMatch.match.length > 0 &&
                 fromMatch.match.length !== toMatch.match.length) return;
@@ -800,19 +808,29 @@
     function isEquivPatternEnv(toEnv, fromEnv, repeat, prefix) {
         return _.all(fromEnv, function(patternVal, patternKey) {
             var patternName = prefix + patternKey;
-            if (_.has(toEnv, patternName)) {
+            if (!_.has(toEnv, patternName)) return true;
+            var fromVal = patternVal;
+            if (repeat) {
+                var nextLevel = patternVal.level + 1;
                 // if repeat and also toEnv.repeat then you just
                 // compare levels
-                if (repeat && toEnv[patternName].repeat) {
-                    return toEnv[patternName].level === patternVal.level + 1;
-                } else {
-                    return isEquivPatternEnvMatch(toEnv[patternName], patternVal);
-                    // otherwise the tokens have to match
-                    // (this comment has be below the return due to bug #464)
+                if(toEnv[patternName].repeat) {
+                    return toEnv[patternName].level === nextLevel;
+                }
+                fromVal = {
+                    level: nextLevel,
+                    match: [patternVal]
                 }
             }
-            return true;
+            return isEquivPatternEnvMatch(toEnv[patternName], fromVal);
         });
+    }
+
+    // flattens the match by one level
+    function decreaseLevel(match) {
+        return match.length === 0 ? [] : match[0].match;
+        // we know isEquivPatternEnv is true, so no need to check anything
+        // (this comment has to be below the return due to bug #464)
     }
 
     // Returns a pattern environment or null if incompatible
@@ -824,16 +842,28 @@
             var patternName = prefix + patternKey;
             if (repeat) {
                 var nextLevel = patternVal.level + 1;
-                if (toEnv[patternName]) {
+                if (toEnv[patternName] && toEnv[patternName].match) {
                     if (toEnv[patternName].repeat) {
                         toEnv[patternName].match.push(patternVal);
                     }
                 } else {
+                    var match = [patternVal];
+                    var repMatch = true;
+                    if (toEnv[patternName]) {
+                        while (match.length > 0 &&
+                               nextLevel > toEnv[patternName].level) {
+                            match = decreaseLevel(match);
+                            nextLevel--;
+                            repMatch = false;
+                        }
+                    }
                     toEnv[patternName] = {
                         level: nextLevel,
-                        match: [patternVal],
+                        match: match,
                         topLevel: topLevel,
-                        repeat: true
+                        // if there was a prior uninitialized match with a
+                        // lower level, then this is not just a repitition
+                        repeat: repMatch
                     };
                 }
             } else {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -763,6 +763,7 @@
     function isEquivPatternEnvToken(toToken, fromToken) {
         if (!toToken) return;
         if (fromToken.type !== toToken.type) return;
+        if (fromToken.type === parser.Token.EOF) return true;
         if (fromToken.value !== toToken.value) return;
         if (fromToken.type !== parser.Token.Delimiter) return true;
         if (fromToken.inner.length !== toToken.inner.length) return;

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -82,16 +82,35 @@
     // fn :: a -> Token -> a
     // stx :: [Token] (can be nested)
     // initial :: a
-    function foldReadTree(fn, stx, initial) {
+    function foldReadTree(fn, stx, initial, path, i) {
         var current = initial;
+        if (!path) {
+            path = [stx];
+        } else {
+            path.push(i, stx);
+        }
         for (var i = 0; i < stx.length; i++) {
-            current = fn(current, stx.slice(i));
+            current = fn(current, stx.slice(i), path);
             var tok = stx[i].token ? stx[i].token : stx[i];
             if (tok.type === parser.Token.Delimiter) {
-                current = foldReadTree(fn, tok.inner, current);
+                current = foldReadTree(fn, tok.inner, current, path, i);
             }
         }
+        path.pop();
+        path.pop();
         return current;
+    }
+
+    // create a new tree by walking the path up and replacing nodes
+    function replaceInTree(newChildren, path) {
+        if (path.length === 0) {
+            return newChildren;
+        }
+        var parentStx = path.pop();
+        var parent = _.find(parentStx, function(p) {
+            return p.token.value.inner === newChildren;
+        });
+
     }
 
     function findMacros(stx) {

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -23,17 +23,7 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-// DONE
-// support simple macro classes
-// get replacement
-// check whether replacement compiles
-// do not match own macro definition
-//
 // TODO
-// command line interface
-// editor integration
-//
-// Future:
 // custom macro classes
 // scope-sensitive reverse matching
 // nested macros
@@ -105,9 +95,14 @@
         }
         var parentIdx = path.pop();
         var parentStx = path.pop();
-        var parentCopy = _.clone(parentStx[parentIdx]);
+        var parentCopy = Object.create(Object.getPrototypeOf(parentStx[parentIdx]));
+        for (var key in parentStx[parentIdx]) {
+            if (parentStx[parentIdx].hasOwnProperty(key)) {
+                parentCopy[key] = parentStx[parentIdx][key];
+            }
+        }
         parentCopy.token = _.clone(parentCopy.token);
-        parentCopy.token.inner = newstx;
+        parentCopy.token.inner = newStx;
         var newParentStx = _(parentStx).toArray();
         newParentStx[parentIdx] = parentCopy;
         return replaceInTree(newParentStx, path);
@@ -246,7 +241,7 @@
         var matched =  _.initial(rest, res.rest.length);
         var rep = patternModule.transcribe(this.pattern, 0, res.patternEnv);
         var newStx = _.flatten([init, rep, res.rest], true);
-        var newTree = replaceInTree(newStx, _.initial(path, 2));
+        // var newTree = replaceInTree(newStx, _.initial(path, 2));
         var prefix = src.slice(0, startRange(rest[0]));
         var suffix = src.slice(Math.min(src.length, startRange(res.rest[0])));
         var repSrc = syntax.prettyPrint(expander.flatten(rep));
@@ -270,13 +265,14 @@
         var stx = parser.read(src);
         stx = expander.adjustLineContext(stx, stx[0]);
         var macros = findMacros(src);
-        return foldReadTree(function(matches, init, rest, path) {
+        var res = foldReadTree(function(matches, init, rest, path) {
             for (var i = 0; i < macros.length; i++) {
                 var match = macros[i].tryMatch(init, rest, path, src);
                 if (match) matches.push(match);
             }
             return matches;
         }, stx, []);
+        return res;
     }
 
     exports.findMacros = findMacros;

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -23,6 +23,22 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+// TODO
+// support simple macro classes
+// get replacement
+// check whether replacement compiles
+// do not match own macro definition
+// coalesce replacements
+// replace all
+// editor integration
+//
+// Future:
+// custom macro classes
+// scope-sensitive reverse matching
+// nested macros
+// named bindings
+// verbatim labeled statements
+
 (function (root, factory) {
     if (typeof exports === 'object') {
         // CommonJS
@@ -30,6 +46,7 @@
                 require('underscore'),
                 require('./parser'),
                 require("./patterns"),
+                require("./syntax"),
                 require('escodegen'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -41,7 +58,7 @@
                 'patterns',
                 'escodegen'], factory);
     }
-}(this, function(exports, _, parser, patternModule, gen) {
+}(this, function(exports, _, parser, patternModule, syntax, gen) {
     'use strict';
     // escodegen still doesn't quite support AMD: https://github.com/Constellation/escodegen/issues/115
     var codegen = typeof escodegen !== "undefined" ? escodegen : gen;
@@ -51,7 +68,9 @@
         return _.initial(patternModule.loadPattern(parser.read(src)));
     }
 
+    var macroPattern = asPattern("macro $n { $e ... }");
     var rulePattern = asPattern("rule { $p ... } => { $e ... }");
+    var expandN = _.initial(parser.read("$n"));
     var expandP = _.initial(parser.read("$p..."));
     var expandE = _.initial(parser.read("$e..."));
 
@@ -64,46 +83,97 @@
         var current = initial;
         for (var i = 0; i < stx.length; i++) {
             current = fn(current, stx.slice(i));
-            if (stx[i].token.type === parser.Token.Delimiter) {
-                current = foldReadTree(fn, stx[i].token.inner, current);
+            var tok = stx[i].token ? stx[i].token : stx[i];
+            if (tok.type === parser.Token.Delimiter) {
+                current = foldReadTree(fn, tok.inner, current);
             }
         }
         return current;
     }
 
-    function findMacroRules(stx) {
+    function findMacros(stx) {
         return foldReadTree(function(macros, rest) {
-            var res = patternModule.matchPatterns(rulePattern, rest, {env: {}});
-            if (res.success) macros.push({
-                pattern: patternModule.transcribe(expandP, 0, res.patternEnv),
-                expansion: patternModule.transcribe(expandE, 0, res.patternEnv)
-            });
+            var res = patternModule.matchPatterns(macroPattern, rest,
+                                                  {env: {}}, true);
+            if (res.success) {
+                var name = patternModule.transcribe(expandN, 0, res.patternEnv);
+                var con = patternModule.transcribe(expandE, 0, res.patternEnv);
+                return macros.concat(findMacroRules(name, con));
+            }
             return macros;
         }, stx, []);
     }
 
-    function findReverseMatches(stx) {
-        debugger;
-        var patterns = findMacroRules(stx).map(function(rule) {
-            return patternModule.loadPattern(rule.expansion);
+    function findMacroRules(name, stx) {
+        return foldReadTree(function(macros, rest) {
+            var res = patternModule.matchPatterns(rulePattern, rest,
+                                                  {env: {}}, true);
+            if (res.success) macros.push(new MacroRule(name, res.patternEnv));
+            return macros;
+        }, stx, []);
+    }
+
+    function MacroRule(name, patternEnv) {
+        this.expansion = patternModule.transcribe(expandE, 0, patternEnv);
+        this.expansionRule = patternModule.loadPattern(this.expansion);
+        this.pattern = patternModule.transcribe(expandP, 0, patternEnv);
+        this.pattern = name.concat(this.pattern);
+        this.patternRule = patternModule.loadPattern(this.pattern);
+        this.addClassesToExpansionPattern();
+    }
+
+    MacroRule.prototype.addClassesToExpansionPattern = function() {
+        var env = {};
+        foldReadTree(function(t, rest) {
+            var tok = rest[0];
+            if (!tok) return;
+            if (tok.type === parser.Token.Identifier && tok.class != 'token') {
+                env[tok.value] = tok.class;
+            }
+        }, this.patternRule);
+        foldReadTree(function(t, rest) {
+            var tok = rest[0];
+            if (!tok) return;
+            if (tok.type === parser.Token.Identifier && env[tok.value]) {
+                tok.class = env[tok.value];
+            }
+        }, this.expansionRule);
+    }
+
+    MacroRule.prototype.removeClasses = function(rest) {
+        this.pattern = _(this.pattern).filter(function(token) {
+
         });
+    }
+
+    MacroRule.prototype.tryMatch = function(rest) {
+        var c = {env: {}};
+        var res = patternModule.matchPatterns(this.expansionRule, rest, c, true);
+        if (!res.success || rest.length === res.rest.length) return;
+
+        var rep =
+            syntax.prettyPrint(
+                syntax.joinSyntaxArray(
+                        patternModule.transcribe(this.pattern, 0, res.patternEnv)));
+
+        return {
+            matchedTokens: _.initial(rest, res.rest.length),
+            replacement: rep,
+            replacementSrc: codegen.generate(rep)
+        }
+    }
+
+    function findReverseMatches(stx) {
+        var macros = findMacros(stx);
         return foldReadTree(function(matches, rest) {
-            for (var i = 0; i < patterns.length; i++) {
-                var ctx = {env: {}};
-                var res = patternModule.matchPatterns(patterns[i], rest, ctx, true);
-                // if matched and actually consumed tokens
-                if (res.success && rest.length > res.rest.length) {
-                    // TODO add replemcement and test whether it compiles
-                    matches.push({
-                        matchedTokens: _.initial(rest, res.rest.length),
-                        replacement: "<not implemented yet>"
-                    });
-                }
+            for (var i = 0; i < macros.length; i++) {
+                var match = macros[i].tryMatch(rest);
+                if (match) matches.push(match);
             }
             return matches;
         }, stx, []);
     }
 
-    exports.findMacroRules = findMacroRules;
+    exports.findMacros = findMacros;
     exports.findReverseMatches = findReverseMatches;
 }));

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -46,10 +46,14 @@
     // escodegen still doesn't quite support AMD: https://github.com/Constellation/escodegen/issues/115
     var codegen = typeof escodegen !== "undefined" ? escodegen : gen;
 
-    var rulePatternSrc = "rule { $p ... } => { $e ... }";
 
-    var rulePattern = _.initial(patternModule.loadPattern(
-            parser.read(rulePatternSrc)));
+    function asPattern(src) {
+        return _.initial(patternModule.loadPattern(parser.read(src)));
+    }
+
+    var rulePattern = asPattern("rule { $p ... } => { $e ... }");
+    var expandP = _.initial(parser.read("$p..."));
+    var expandE = _.initial(parser.read("$e..."));
 
     // Pre-order traversal of read tree, provides rest tokens at each step
     //
@@ -71,12 +75,35 @@
         return foldReadTree(function(macros, rest) {
             var res = patternModule.matchPatterns(rulePattern, rest, {env: {}});
             if (res.success) macros.push({
-                pattern: res.patternEnv['$p'],
-                expansion: res.patternEnv['$e']
+                pattern: patternModule.transcribe(expandP, 0, res.patternEnv),
+                expansion: patternModule.transcribe(expandE, 0, res.patternEnv)
             });
             return macros;
         }, stx, []);
     }
 
+    function findReverseMatches(stx) {
+        debugger;
+        var patterns = findMacroRules(stx).map(function(rule) {
+            return patternModule.loadPattern(rule.expansion);
+        });
+        return foldReadTree(function(matches, rest) {
+            for (var i = 0; i < patterns.length; i++) {
+                var ctx = {env: {}};
+                var res = patternModule.matchPatterns(patterns[i], rest, ctx, true);
+                // if matched and actually consumed tokens
+                if (res.success && rest.length > res.rest.length) {
+                    // TODO add replemcement and test whether it compiles
+                    matches.push({
+                        matchedTokens: _.initial(rest, res.rest.length),
+                        replacement: "<not implemented yet>"
+                    });
+                }
+            }
+            return matches;
+        }, stx, []);
+    }
+
     exports.findMacroRules = findMacroRules;
+    exports.findReverseMatches = findReverseMatches;
 }));

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -23,9 +23,11 @@
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-// TODO
+// DONE
 // support simple macro classes
 // get replacement
+//
+// TODO
 // check whether replacement compiles
 // do not match own macro definition
 // coalesce replacements
@@ -47,6 +49,7 @@
                 require('./parser'),
                 require("./patterns"),
                 require("./syntax"),
+                require("./expander"),
                 require('escodegen'));
     } else if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
@@ -58,7 +61,7 @@
                 'patterns',
                 'escodegen'], factory);
     }
-}(this, function(exports, _, parser, patternModule, syntax, gen) {
+}(this, function(exports, _, parser, patternModule, syntax, expander, gen) {
     'use strict';
     // escodegen still doesn't quite support AMD: https://github.com/Constellation/escodegen/issues/115
     var codegen = typeof escodegen !== "undefined" ? escodegen : gen;
@@ -152,14 +155,13 @@
         if (!res.success || rest.length === res.rest.length) return;
 
         var rep =
-            syntax.prettyPrint(
-                syntax.joinSyntaxArray(
-                        patternModule.transcribe(this.pattern, 0, res.patternEnv)));
+            expander.flatten(
+                patternModule.transcribe(this.pattern, 0, res.patternEnv));
 
         return {
             matchedTokens: _.initial(rest, res.rest.length),
             replacement: rep,
-            replacementSrc: codegen.generate(rep)
+            replacementSrc: syntax.prettyPrint(rep)
         }
     }
 

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -1,0 +1,82 @@
+/*
+  Copyright (C) 2015 Tim Disney <tim@disnet.me>
+
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+(function (root, factory) {
+    if (typeof exports === 'object') {
+        // CommonJS
+        factory(exports,
+                require('underscore'),
+                require('./parser'),
+                require("./patterns"),
+                require('escodegen'));
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['exports',
+                'underscore',
+                'parser',
+                'syntax',
+                'scopedEval',
+                'patterns',
+                'escodegen'], factory);
+    }
+}(this, function(exports, _, parser, patternModule, gen) {
+    'use strict';
+    // escodegen still doesn't quite support AMD: https://github.com/Constellation/escodegen/issues/115
+    var codegen = typeof escodegen !== "undefined" ? escodegen : gen;
+
+    var rulePatternSrc = "rule { $p ... } => { $e ... }";
+
+    var rulePattern = _.initial(patternModule.loadPattern(
+            parser.read(rulePatternSrc)));
+
+    // Pre-order traversal of read tree, provides rest tokens at each step
+    //
+    // fn :: a -> Token -> a
+    // stx :: [Token] (can be nested)
+    // initial :: a
+    function foldReadTree(fn, stx, initial) {
+        var current = initial;
+        for (var i = 0; i < stx.length; i++) {
+            current = fn(current, stx.slice(i));
+            if (stx[i].token.type === parser.Token.Delimiter) {
+                current = foldReadTree(fn, stx[i].token.inner, current);
+            }
+        }
+        return current;
+    }
+
+    function findMacroRules(stx) {
+        return foldReadTree(function(macros, rest) {
+            var res = patternModule.matchPatterns(rulePattern, rest, {env: {}});
+            if (res.success) macros.push({
+                pattern: res.patternEnv['$p'],
+                expansion: res.patternEnv['$e']
+            });
+            return macros;
+        }, stx, []);
+    }
+
+    exports.findMacroRules = findMacroRules;
+}));

--- a/src/sjs.js
+++ b/src/sjs.js
@@ -40,8 +40,8 @@ var argv = require("optimist")
     .describe('format-indent', 'number of spaces for indentation')
     .alias('l', 'load-readtable')
     .describe('load-readtable', 'readtable module to install')
-    .boolean('reverse')
-    .describe('reverse', 'finds possible locations for macro usage')
+    .boolean('refactor')
+    .describe('refactor', 'macrofy the input by finding possible locations for macro invocations')
     .argv;
 
 
@@ -61,7 +61,7 @@ exports.run = function() {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
-    var reverse = argv.reverse;
+    var refactor = argv.refactor;
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }
@@ -119,12 +119,9 @@ exports.run = function() {
         }
     }
 
-    if (reverse) {
+    if (refactor) {
         var match = rev.findReverseMatches(file)[0];
-        if (!match) return console.log("no reverse matches found");
-        console.log("replaced\n\n" + match.matchedSrc + "\nwith\n\n"
-                + match.replacement);
-
+        if (!match) return console.log("no macorfication candidates found");
         if (outfile) {
             fs.writeFileSync(outfile, match.replacedSrc);
         } else {

--- a/src/sjs.js
+++ b/src/sjs.js
@@ -61,7 +61,7 @@ exports.run = function() {
     var readableNames = argv['readable-names'];
     var formatIndent = parseInt(argv['format-indent'], 10);
     var readtableModules = argv['load-readtable'];
-    var reverse = argv['reverse'];
+    var reverse = argv.reverse;
     if (formatIndent !== formatIndent) {
         formatIndent = 4;
     }

--- a/test/test_macro_patterns.js
+++ b/test/test_macro_patterns.js
@@ -1261,5 +1261,4 @@ describe("macro expander", function() {
         expect(m [1 2] [2 3]).to.eql([3, 5]);
         expect(m []).to.eql([0]);
     });
-
 });

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -12,7 +12,10 @@ var letMacro = "macro let {    rule { $($id:ident = $val:expr) (,) ... } =>" +
                "                    { $(var $id = $val;) ... } }";
 
 var swapMacro = "macro swap {  rule { $x:ident, $y:ident } =>" +
-                "                   { var tmp = $x; $x = $y; $y = tmp; }}"
+                "                   { var tmp = $x; $x = $y; $y = tmp; }}";
+
+var swapMacro2 = "macro swap {  rule { $x:expr, $y:expr } =>" +
+                 "                   { var $tmp = $x; $x = $y; $y = $tmp; }}";
 
 describe("reverse.findMacros", function() {
     it("should return pattern and expansion for id macro", function() {
@@ -65,6 +68,12 @@ describe("reverse.findReverseMatches", function() {
     it("should respect pattern classes for swap macro", function() {
         var matches = reverse.findReverseMatches(swapMacro + "\nvar a,b; var tmp = (a[0]); (a[0]) = b; b = tmp;");
         expect(matches).to.have.length(0);
+    });
+
+    it.skip("should return possible matches for swap with expressions", function() {
+        // this test fails because of issue #470
+        var matches = reverse.findReverseMatches(swapMacro2 + "\nvar a,b; var t = a[0]; a[0] = b; b = t;");
+        expect(matches).to.have.length(1);
     });
 
     it("should adjust levels in the environment", function() {

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -67,8 +67,27 @@ describe("reverse.findReverseMatches", function() {
         expect(matches).to.have.length(0);
     });
 
-    it("macro", function() {
-        reverse.findReverseMatches("macro tom { rule { $x:token } => { ( $x ) } }");
+    it("should adjust levels in the environment", function() {
+        var s = "macro m { rule { $x $y ... } => { $( $x $y ) ... } }\n";
+        s += "+ 1 + 2";
+        var matches = reverse.findReverseMatches(s);
+        expect(matches).to.have.length(3);
+        expect(matches[0].replacement).to.be("m + 1 2\n");
+        expect(matches[1].replacement).to.be("m 1 +\n");
+        expect(matches[2].replacement).to.be("m + 2\n");
+    });
+
+    var classMacro = "macro class { rule { $typename {" +
+        "constructor $cparams $cbody $($mname $mparams $mbody) ..." +
+        "} } => { function $typename $cparams $cbody " +
+        "$($typename.prototype.$mname = function $mname $mparams $mbody;) ...}}";
+
+    it("reverse match class macro", function() {
+        var s = classMacro + "function Node(a) { this.a = 23; }";
+        s += "Node.prototype.toString = ";
+        s += "function toString() { return this.a; };";
+        var matches = reverse.findReverseMatches(s);
+        expect(matches).to.have.length(1);
     });
 });
 

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -14,9 +14,6 @@ var letMacro = "macro let {    rule { $($id:ident = $val) (,) ... } =>" +
 var swapMacro = "macro swap {  rule { $x:ident, $y:ident } =>" +
                 "                   { var tmp = $x; $x = $y; $y = tmp; }}";
 
-var swapMacro2 = "macro swap {  rule { $x:expr, $y:expr } =>" +
-                 "                   { var $tmp = $x; $x = $y; $y = $tmp; }}";
-
 var inc3Macro = "macro inc { rule { 1 } => { 3 } " +
                 "            rule { $x } => { $x + 1 } }"
 
@@ -77,12 +74,6 @@ describe("reverse.findReverseMatches", function() {
     it("should respect pattern classes for swap macro", function() {
         var matches = reverse.findReverseMatches(swapMacro + "\nvar a,b; var tmp = (a[0]); (a[0]) = b; b = tmp;");
         expect(matches).to.have.length(0);
-    });
-
-    it.skip("should return possible matches for swap with expressions", function() {
-        // this test fails because of issue #470
-        var matches = reverse.findReverseMatches(swapMacro2 + "\nvar a,b; var t = a[0]; a[0] = b; b = t;");
-        expect(matches).to.have.length(1);
     });
 
     it("should adjust levels in the environment", function() {

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -7,57 +7,47 @@ var _ = require("underscore");
 
 var Token = parser.Token;
 
-function findMacros(src) {
-    var stx = parser.read(src);
-    return reverse.findMacros(stx);
-}
-
-var idMacro  = "macro id {\n  rule {\n    ( $x )\n  }\n  => {\n    $x\n  }\n  \n}\n";
+var idMacro  = "macro id {\n  rule { ( $x ) } => { $x }\n}";
 var letMacro = "macro let {    rule { $($id:ident = $val:expr) (,) ... } =>" +
                "                    { $(var $id = $val;) ... } }";
 
 var swapMacro = "macro swap {  rule { $x:ident, $y:ident } =>" +
                 "                   { var tmp = $x; $x = $y; $y = tmp; }}"
 
-describe("findMacros", function() {
+describe("reverse.findMacros", function() {
     it("should return pattern and expansion for id macro", function() {
-        var macros = findMacros(idMacro);
+        var macros = reverse.findMacros(idMacro);
         expect(macros).to.have.length(1);
         expect(macros[0]).to.have.property("pattern");
         expect(macros[0]).to.have.property("expansion");
     });
     it("should return pattern and expansion for let macro", function() {
-        var macros = findMacros(letMacro);
+        var macros = reverse.findMacros(letMacro);
         expect(macros).to.have.length(1);
         expect(macros[0]).to.have.property("pattern");
         expect(macros[0]).to.have.property("expansion");
     });
     it("should return pattern and expansion for swap macro", function() {
-        var macros = findMacros(swapMacro);
+        var macros = reverse.findMacros(swapMacro);
         expect(macros).to.have.length(1);
         expect(macros[0]).to.have.property("pattern");
         expect(macros[0]).to.have.property("expansion");
     });
 });
 
-function findReverseMatches(src) {
-    var stx = parser.read(src);
-    return reverse.findReverseMatches(stx);
-}
-
-describe("findReverseMatches", function() {
+describe("reverse.findReverseMatches", function() {
     it("should return possible reverse match for id macro", function() {
-        var matches = findReverseMatches(idMacro + "\n23");
+        var matches = reverse.findReverseMatches(idMacro + "\n23");
         expect(matches).to.have.length(1);
         expect(matches[0]).to.have.property("matchedTokens");
         expect(matches[0].matchedTokens).to.have.length(1);
         expect(matches[0].matchedTokens[0].token.value).to.be(23);
         expect(matches[0].replacement).to.be("id ( 23 )\n");
-        expect(matches[0].replacedSrc).to.be(idMacro + "id ( 23 )\n");
+        expect(matches[0].replacedSrc).to.be(idMacro + "\nid ( 23 )\n");
     });
 
     it("should return possible reverse match for let macro", function() {
-        var matches = findReverseMatches(letMacro + "\nvar a = 1; var b = 2;");
+        var matches = reverse.findReverseMatches(letMacro + "\nvar a = 1; var b = 2;");
         expect(matches).to.have.length(2);
         expect(matches[0].matchedTokens).to.have.length(10);
         expect(matches[0].replacement).to.be("let a = ( 1 ) , b = ( 2 )\n");
@@ -66,19 +56,19 @@ describe("findReverseMatches", function() {
     });
 
     it("should return possible reverse match for swap macro", function() {
-        var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = a; a = b; b = tmp;");
+        var matches = reverse.findReverseMatches(swapMacro + "\nvar a,b; var tmp = a; a = b; b = tmp;");
         expect(matches).to.have.length(1);
         expect(matches[0].matchedTokens).to.have.length(13);
         expect(matches[0].replacement).to.be("swap a , b\n");
     });
 
     it("should respect pattern classes for swap macro", function() {
-        var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = (a[0]); (a[0]) = b; b = tmp;");
+        var matches = reverse.findReverseMatches(swapMacro + "\nvar a,b; var tmp = (a[0]); (a[0]) = b; b = tmp;");
         expect(matches).to.have.length(0);
     });
 
     it("macro", function() {
-        findReverseMatches("macro tom { rule { $x:token } => { ( $x ) } }");
+        reverse.findReverseMatches("macro tom { rule { $x:token } => { ( $x ) } }");
     });
 });
 

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -59,17 +59,17 @@ describe("findReverseMatches", function() {
     it("should return possible reverse match for let macro", function() {
         var matches = findReverseMatches(letMacro + "\nvar a = 1; var b = 2;");
         expect(matches).to.have.length(2);
-        expect(matches[0].matchedTokens).to.have.length(8);
-        expect(matches[0].replacement).to.be("let a = 1, b = 2");
-        expect(matches[1].matchedTokens).to.have.length(4);
-        expect(matches[1].replacement).to.be("let b = 2");
+        expect(matches[0].matchedTokens).to.have.length(10);
+        expect(matches[0].replacement).to.be("let a = ( 1 ) , b = ( 2 )\n");
+        expect(matches[1].matchedTokens).to.have.length(5);
+        expect(matches[1].replacement).to.be("let b = ( 2 )\n");
     });
 
     it("should return possible reverse match for swap macro", function() {
         var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = a; a = b; b = tmp;");
         expect(matches).to.have.length(1);
-        expect(matches[0].matchedTokens).to.have.length(10);
-        expect(matches[0].replacement).to.be("swap ( a , b )");
+        expect(matches[0].matchedTokens).to.have.length(13);
+        expect(matches[0].replacement).to.be("swap a , b\n");
     });
 
     it("should respect pattern classes for swap macro", function() {

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -12,12 +12,12 @@ function findMacros(src) {
     return reverse.findMacros(stx);
 }
 
-var idMacro  = "macro id  { rule { ( $x ) } => { $x } }";
-var letMacro = "macro let { rule { $($id:ident = $val:expr) (,) ... } =>" +
-               "                 { $(var $id = $val;) ... } }";
+var idMacro  = "macro id {\n  rule {\n    ( $x )\n  }\n  => {\n    $x\n  }\n  \n}\n";
+var letMacro = "macro let {    rule { $($id:ident = $val:expr) (,) ... } =>" +
+               "                    { $(var $id = $val;) ... } }";
 
-var swapMacro = "macro swap { rule { $x:ident, $y:ident } =>" +
-                "                  { var tmp = $x; $x = $y; $y = tmp; }}"
+var swapMacro = "macro swap {  rule { $x:ident, $y:ident } =>" +
+                "                   { var tmp = $x; $x = $y; $y = tmp; }}"
 
 describe("findMacros", function() {
     it("should return pattern and expansion for id macro", function() {
@@ -47,32 +47,34 @@ function findReverseMatches(src) {
 
 describe("findReverseMatches", function() {
     it("should return possible reverse match for id macro", function() {
-        debugger;
         var matches = findReverseMatches(idMacro + "\n23");
-        expect(matches).to.have.length(11);
+        expect(matches).to.have.length(1);
         expect(matches[0]).to.have.property("matchedTokens");
-        expect(matches[0]).to.have.property("replacement");
+        expect(matches[0].matchedTokens).to.have.length(1);
+        expect(matches[0].matchedTokens[0].token.value).to.be(23);
+        expect(matches[0].replacement).to.be("id ( 23 )\n");
+        expect(matches[0].replacedSrc).to.be(idMacro + "id ( 23 )\n");
     });
 
     it("should return possible reverse match for let macro", function() {
         var matches = findReverseMatches(letMacro + "\nvar a = 1; var b = 2;");
-        expect(matches).to.have.length(3);
-        expect(matches[0]).to.have.property("matchedTokens");
-        expect(matches[0]).to.have.property("replacement");
+        expect(matches).to.have.length(2);
+        expect(matches[0].matchedTokens).to.have.length(8);
+        expect(matches[0].replacement).to.be("let a = 1, b = 2");
+        expect(matches[1].matchedTokens).to.have.length(4);
+        expect(matches[1].replacement).to.be("let b = 2");
     });
 
     it("should return possible reverse match for swap macro", function() {
         var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = a; a = b; b = tmp;");
-        expect(matches).to.have.length(2);
-        expect(matches[0]).to.have.property("matchedTokens");
-        expect(matches[0]).to.have.property("replacement");
+        expect(matches).to.have.length(1);
+        expect(matches[0].matchedTokens).to.have.length(10);
+        expect(matches[0].replacement).to.be("swap ( a , b )");
     });
 
     it("should respect pattern classes for swap macro", function() {
         var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = (a[0]); (a[0]) = b; b = tmp;");
-        expect(matches).to.have.length(1);
-        expect(matches[0]).to.have.property("matchedTokens");
-        expect(matches[0]).to.have.property("replacement");
+        expect(matches).to.have.length(0);
     });
 
     it("macro", function() {

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -12,14 +12,43 @@ function findMacros(src) {
     return reverse.findMacroRules(stx);
 }
 
+var idMacro  = "macro id  { rule { ( $x ) } => { $x } }";
+var letMacro = "macro let { rule { $($id = $val) (,) ... } =>" +
+               "          { $(var $id = $val;) ... } }";
+
 describe("findMacroRules", function() {
-    it("should return all macros", function() {
-        debugger;
-        var src = "macro id { rule { ( $x ) } => { $x } }";
-        var macros = findMacros(src);
+    it("should return pattern and expansion for id macro", function() {
+        var macros = findMacros(idMacro);
         expect(macros).to.have.length(1);
         expect(macros[0]).to.have.property("pattern");
         expect(macros[0]).to.have.property("expansion");
     });
-
+    it("should return pattern and expansion for let macro", function() {
+        var macros = findMacros(letMacro);
+        expect(macros).to.have.length(1);
+        expect(macros[0]).to.have.property("pattern");
+        expect(macros[0]).to.have.property("expansion");
+    });
 });
+
+function findReverseMatches(src) {
+    var stx = parser.read(src);
+    return reverse.findReverseMatches(stx);
+}
+
+describe("findReverseMatches", function() {
+    it("should return possible reverse match for id macro", function() {
+        var matches = findReverseMatches(idMacro + "\n23");
+        expect(matches).to.have.length(11);
+        expect(matches[0]).to.have.property("matchedTokens");
+        expect(matches[0]).to.have.property("replacement");
+    });
+
+    it("should return possible reverse match for let macro", function() {
+        var matches = findReverseMatches(letMacro + "\nvar a = 1; var b = 2;");
+        expect(matches).to.have.length(3);
+        expect(matches[0]).to.have.property("matchedTokens");
+        expect(matches[0]).to.have.property("replacement");
+    });
+});
+

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -1,0 +1,25 @@
+var expect = require("expect.js");
+var parser = require("../build/lib/parser");
+var reverse = require("../build/lib/reverse");
+var syn = require("../build/lib/syntax");
+var gen = require("escodegen");
+var _ = require("underscore");
+
+var Token = parser.Token;
+
+function findMacros(src) {
+    var stx = parser.read(src);
+    return reverse.findMacroRules(stx);
+}
+
+describe("findMacroRules", function() {
+    it("should return all macros", function() {
+        debugger;
+        var src = "macro id { rule { ( $x ) } => { $x } }";
+        var macros = findMacros(src);
+        expect(macros).to.have.length(1);
+        expect(macros[0]).to.have.property("pattern");
+        expect(macros[0]).to.have.property("expansion");
+    });
+
+});

--- a/test/test_reverse.js
+++ b/test/test_reverse.js
@@ -9,14 +9,17 @@ var Token = parser.Token;
 
 function findMacros(src) {
     var stx = parser.read(src);
-    return reverse.findMacroRules(stx);
+    return reverse.findMacros(stx);
 }
 
 var idMacro  = "macro id  { rule { ( $x ) } => { $x } }";
-var letMacro = "macro let { rule { $($id = $val) (,) ... } =>" +
-               "          { $(var $id = $val;) ... } }";
+var letMacro = "macro let { rule { $($id:ident = $val:expr) (,) ... } =>" +
+               "                 { $(var $id = $val;) ... } }";
 
-describe("findMacroRules", function() {
+var swapMacro = "macro swap { rule { $x:ident, $y:ident } =>" +
+                "                  { var tmp = $x; $x = $y; $y = tmp; }}"
+
+describe("findMacros", function() {
     it("should return pattern and expansion for id macro", function() {
         var macros = findMacros(idMacro);
         expect(macros).to.have.length(1);
@@ -25,6 +28,12 @@ describe("findMacroRules", function() {
     });
     it("should return pattern and expansion for let macro", function() {
         var macros = findMacros(letMacro);
+        expect(macros).to.have.length(1);
+        expect(macros[0]).to.have.property("pattern");
+        expect(macros[0]).to.have.property("expansion");
+    });
+    it("should return pattern and expansion for swap macro", function() {
+        var macros = findMacros(swapMacro);
         expect(macros).to.have.length(1);
         expect(macros[0]).to.have.property("pattern");
         expect(macros[0]).to.have.property("expansion");
@@ -38,6 +47,7 @@ function findReverseMatches(src) {
 
 describe("findReverseMatches", function() {
     it("should return possible reverse match for id macro", function() {
+        debugger;
         var matches = findReverseMatches(idMacro + "\n23");
         expect(matches).to.have.length(11);
         expect(matches[0]).to.have.property("matchedTokens");
@@ -49,6 +59,24 @@ describe("findReverseMatches", function() {
         expect(matches).to.have.length(3);
         expect(matches[0]).to.have.property("matchedTokens");
         expect(matches[0]).to.have.property("replacement");
+    });
+
+    it("should return possible reverse match for swap macro", function() {
+        var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = a; a = b; b = tmp;");
+        expect(matches).to.have.length(2);
+        expect(matches[0]).to.have.property("matchedTokens");
+        expect(matches[0]).to.have.property("replacement");
+    });
+
+    it("should respect pattern classes for swap macro", function() {
+        var matches = findReverseMatches(swapMacro + "\nvar a,b; var tmp = (a[0]); (a[0]) = b; b = tmp;");
+        expect(matches).to.have.length(1);
+        expect(matches[0]).to.have.property("matchedTokens");
+        expect(matches[0]).to.have.property("replacement");
+    });
+
+    it("macro", function() {
+        findReverseMatches("macro tom { rule { $x:token } => { ( $x ) } }");
     });
 });
 


### PR DESCRIPTION
For rule macros, it is possible to automatically refactor code with macros by using the template (body of the rule macro) to match syntax and replace it with the corresponding macro invocation based on the pattern.  This pull request adds support for this type of "macrofication" refactoring.  In order to use this features, I added a command line flag (-r) and integrated the refactoring into the sweet.js editor.  Using the editor is definitely the preferred way of refactoring as it highlights the code and let's you chose which code to replace by a macro:

![letall](https://cloud.githubusercontent.com/assets/479238/6840293/95e60808-d332-11e4-9e5f-af3d592c6a84.png)

The macrofication option in the editor is off by default but seems to work pretty good.  Limitations are some special kind of "expr" pattern classes and locally scoped macro definitions.  Also, the highlighting is mutually exclusive with the expansion highlighting due to a limitation in CodeMirror.  The only way around this problem would be to write some extension to CodeMirror that supports multiple syntax highlighters at the same time.

This pull request is based on the patch for supporting repeated variables: [#540](https://github.com/mozilla/sweet.js/pull/450).