### PR TITLE
Allow macro names to be punctuators

### DIFF
--- a/src/shift-reader.js
+++ b/src/shift-reader.js
@@ -11,6 +11,7 @@ import Term from './terms';
 
 const LSYNTAX = { name: 'left-syntax' };
 const RSYNTAX = { name: 'right-syntax' };
+const AT = { klass: TokenClass.Punctuator, name: "@" };
 
 
 // TODO: also, need to handle contextual yield
@@ -409,6 +410,16 @@ export default class Reader extends Tokenizer {
         type: TokenType.IDENTIFIER,
         value: '#',
         slice: slice
+      };
+    } else if (charCode === 64) { // @
+      let startLocation = this.getLocation();
+      let start = this.index;
+      let slice = this.getSlice(start, startLocation);
+      this.index++;
+      return {
+        type: AT,
+        value: '@',
+        slice
       };
     }
 

--- a/test/test_macro_expansion.js
+++ b/test/test_macro_expansion.js
@@ -212,3 +212,26 @@ test('should handle iterators inside a syntax template', t => {
     output = x;
   `, 42);
 });
+
+test('should allow macros to be defined with punctuators', t => {
+  testEval(`
+    syntax @ = function (ctx) {
+      return #\`42\`;
+    }
+    output = @
+  `, 42);
+
+  testEval(`
+    syntax # = function (ctx) {
+      return #\`42\`;
+    }
+    output = #
+  `, 42);
+
+  testEval(`
+    syntax * = function (ctx) {
+      return #\`42\`;
+    }
+    output = *
+  `, 42);
+});


### PR DESCRIPTION
Allow macro names to be punctuators. Also allows tokenization of `@` (this was legal pre-1.0). Allows you to do fun things like:

```js
syntax @ = function (ctx) {
  return #`this`;
}
@
```