### PR TITLE
Macro context name via method

### DIFF
--- a/src/macro-context.js
+++ b/src/macro-context.js
@@ -9,6 +9,7 @@ const Just = Maybe.Just;
 const Nothing = Maybe.Nothing;
 
 const symWrap = Symbol('wrapper');
+const symName = Symbol('name');
 
 const isKind = _.curry((kind, t, v) => {
   if (t instanceof Syntax) {
@@ -131,7 +132,7 @@ export default class MacroContext {
   constructor(enf, name, context, useScope, introducedScope) {
     // todo: perhaps replace with a symbol to keep mostly private?
     this._enf = enf;
-    this.name = name;
+    this[symName] = name;
     this.context = context;
     if (useScope && introducedScope) {
       this.noScopes = false;
@@ -141,6 +142,10 @@ export default class MacroContext {
       this.noScopes = true;
     }
     this[Symbol.iterator] = () => this;
+  }
+
+  name() {
+    return new SyntaxOrTermWrapper(this[symName], this.context);
   }
 
   next(type = 'Syntax') {

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -2,6 +2,9 @@ import { parse, compile } from "../src/sweet";
 import expect from "expect.js";
 import { zip, curry, equals, cond, identity, T, and, compose, type, mapObjIndexed, map, keys, has } from 'ramda';
 import { transform } from 'babel-core';
+import Reader from "../src/shift-reader";
+import { Enforester } from "../src/enforester";
+import { List } from "immutable";
 
 function expr(program) {
   return stmt(program).expression;
@@ -9,6 +12,12 @@ function expr(program) {
 
 function stmt(program) {
   return program.items[0];
+}
+
+function makeEnforester(code) {
+  let reader = new Reader(code);
+  let stxl = reader.read();
+  return new Enforester(stxl, List(), {});
 }
 
 export function testParseFailure() {
@@ -67,5 +76,5 @@ export function testThrow(source) {
 }
 
 export {
-  expr, stmt, testParse, testEval
+  makeEnforester, expr, stmt, testParse, testEval
 };

--- a/test/test_enforest.js
+++ b/test/test_enforest.js
@@ -1,17 +1,7 @@
-import { Enforester } from "../src/enforester";
-import { List } from "immutable";
 import { readAsTerms as read } from "../src/sweet";
-import { expr, stmt, testParse } from "./assertions";
-import Reader from "../src/shift-reader";
+import { makeEnforester as mkEnf, expr, stmt, testParse } from "./assertions";
 import expect from "expect.js";
 import test from 'ava';
-
-function mkEnf(code) {
-  let reader = new Reader(code);
-  let stxl = reader.read();
-  return new Enforester(stxl, List(), {});
-}
-
 
 test("should handle zero formal parameters", t => {
   let enf = mkEnf("");

--- a/test/test_macro_context.js
+++ b/test/test_macro_context.js
@@ -1,6 +1,7 @@
 import test from 'ava';
-import { SyntaxOrTermWrapper } from '../src/macro-context';
+import MacroContext, { SyntaxOrTermWrapper } from '../src/macro-context';
 import Syntax from '../src/syntax';
+import { makeEnforester } from './assertions';
 import { List } from 'immutable';
 import { Maybe } from 'ramda-fantasy';
 const Just = Maybe.Just;
@@ -95,4 +96,10 @@ test('a wrapper should work with an inner iterator', t => {
   t.true(foo.value.isIdentifier('foo'));
   t.true(bar.value.isIdentifier('bar'));
   t.true(ctx.next().done);
+});
+
+test('a macro context should have a name', t => {
+  let enf = makeEnforester('a');
+  let ctx = new MacroContext(enf, Syntax.fromIdentifier('foo'), {});
+  t.true(ctx.name().val() === 'foo');
 });


### PR DESCRIPTION
Exposes the macro context name via a method.
```javascript
syntax foo = ctx => {
  ctx.name().val() // foo
  //...
}
foo 42
```
Implements #538